### PR TITLE
[김대건] 회원가입 페이지

### DIFF
--- a/src/components/page/login/LoginBottom.module.css
+++ b/src/components/page/login/LoginBottom.module.css
@@ -1,0 +1,23 @@
+.bottom {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: inherit;
+  height: 136px;
+  gap: 32px;
+}
+
+.bottom > span {
+  font-size: 20px;
+  font-weight: 400;
+  color: var(--black-200);
+}
+
+.snsIcon {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: 32px;
+}

--- a/src/components/page/login/LoginBottom.tsx
+++ b/src/components/page/login/LoginBottom.tsx
@@ -1,0 +1,30 @@
+import style from './LoginBottom.module.css';
+import google from '../../../assets/images/img_login_google_large.svg';
+import kakao from '../../../assets/images/img_login_kakao_large.svg';
+import naver from '../../../assets/images/img_login_naver_large.svg';
+
+export const UserLoginBottom = () => {
+  return (
+    <div className={style.bottom}>
+      <span>SNS 계정으로 간편 가입하기</span>
+      <div className={style.snsIcon}>
+        <img src={google} alt='' />
+        <img src={kakao} alt='' />
+        <img src={naver} alt='' />
+      </div>
+    </div>
+  );
+};
+
+export const DriverLoginBottom = () => {
+  return (
+    <div className={style.bottom}>
+      <span>SNS 계정으로 간편 가입하기</span>
+      <div className={style.snsIcon}>
+        <img src={google} alt='' />
+        <img src={kakao} alt='' />
+        <img src={naver} alt='' />
+      </div>
+    </div>
+  );
+};

--- a/src/components/page/login/LoginInput.tsx
+++ b/src/components/page/login/LoginInput.tsx
@@ -22,7 +22,7 @@ export const EmailInputComponent = ({
           style[value && validation ? 'complete' : '']
         } ${style[value && !validation ? 'invalid' : '']} `}
         value={value ?? ''}
-        placeholder='이메일을 입력 해주세요.'
+        placeholder='이메일을 입력해 주세요.'
         onChange={inputHeandler}
         type='text'
         id='email'
@@ -55,7 +55,7 @@ export const PasswordInputComponent = ({
           type={invisible ? 'password' : 'text'}
           id='password'
           name='password'
-          placeholder='비밀번호을 입력 해주세요.'
+          placeholder='비밀번호을 입력해 주세요.'
         />
         <div className={style.iconPill}>
           {invisible ? (

--- a/src/components/page/login/LoginTop.module.css
+++ b/src/components/page/login/LoginTop.module.css
@@ -1,0 +1,24 @@
+.top {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: inherit;
+  height: 140px;
+  gap: 18px;
+}
+
+p {
+  font-size: 20px;
+  font-weight: 400;
+}
+
+.top > p > a {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--blue-200);
+
+  box-sizing: border-box;
+  padding-left: 8px;
+}

--- a/src/components/page/login/LoginTop.tsx
+++ b/src/components/page/login/LoginTop.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+import style from './LoginTop.module.css';
+import logo from '../../../assets/logo.svg';
+
+export const UserLoginTop = () => {
+  return (
+    <div className={style.top}>
+      <img src={logo} alt='' />
+      <p>
+        기사님이신가요?<Link to='/driver/login'>기사님 전용 페이지</Link>
+      </p>
+    </div>
+  );
+};
+
+export const DriverLoginTop = () => {
+  return (
+    <div className={style.top}>
+      <img src={logo} alt='' />
+      <p>
+        일반 유저라면?<Link to='/user/login'>일반 유저 전용 페이지</Link>
+      </p>
+    </div>
+  );
+};

--- a/src/components/page/signup/SignupBottom.module.css
+++ b/src/components/page/signup/SignupBottom.module.css
@@ -1,0 +1,23 @@
+.bottom {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: inherit;
+  height: 136px;
+  gap: 32px;
+}
+
+.bottom > span {
+  font-size: 20px;
+  font-weight: 400;
+  color: var(--black-200);
+}
+
+.snsIcon {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: 32px;
+}

--- a/src/components/page/signup/SignupBottom.tsx
+++ b/src/components/page/signup/SignupBottom.tsx
@@ -1,0 +1,30 @@
+import style from './SignupBottom.module.css';
+import google from '../../../assets/images/img_login_google_large.svg';
+import kakao from '../../../assets/images/img_login_kakao_large.svg';
+import naver from '../../../assets/images/img_login_naver_large.svg';
+
+export const UserSignupBottom = () => {
+  return (
+    <div className={style.bottom}>
+      <span>SNS 계정으로 간편 가입하기</span>
+      <div className={style.snsIcon}>
+        <img src={google} alt='' />
+        <img src={kakao} alt='' />
+        <img src={naver} alt='' />
+      </div>
+    </div>
+  );
+};
+
+export const DriverSignupBottom = () => {
+  return (
+    <div className={style.bottom}>
+      <span>SNS 계정으로 간편 가입하기</span>
+      <div className={style.snsIcon}>
+        <img src={google} alt='' />
+        <img src={kakao} alt='' />
+        <img src={naver} alt='' />
+      </div>
+    </div>
+  );
+};

--- a/src/components/page/signup/SignupBtn.module.css
+++ b/src/components/page/signup/SignupBtn.module.css
@@ -1,0 +1,22 @@
+.container {
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 64px;
+
+  border-radius: 16px;
+  background-color: var(--gray-100);
+
+  color: white;
+  font-size: 18px;
+  font-weight: 600;
+
+  cursor: pointer;
+}
+
+.container.complete {
+  background-color: var(--blue-300);
+}

--- a/src/components/page/signup/SignupBtn.tsx
+++ b/src/components/page/signup/SignupBtn.tsx
@@ -1,0 +1,16 @@
+import style from './SignupBtn.module.css';
+
+type Props = {
+  context: string;
+  validation: boolean;
+};
+
+export default function SignupBtn({ context, validation }: Props) {
+  return (
+    <button
+      className={`${style.container} ${style[validation ? 'complete' : '']}`}
+    >
+      {context}
+    </button>
+  );
+}

--- a/src/components/page/signup/SignupInput.module.css
+++ b/src/components/page/signup/SignupInput.module.css
@@ -1,0 +1,85 @@
+.none {
+  display: none;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  justify-content: center;
+
+  width: 100%;
+  min-height: 112px;
+  max-height: 146px;
+  gap: 16px;
+}
+.text {
+  font-size: 20px;
+  font-weight: 400;
+  color: black;
+}
+.input {
+  width: 100%;
+  height: 64px;
+
+  box-sizing: border-box;
+  margin: 0;
+  padding-left: 14px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+
+  border-radius: 16px;
+  border: 1px solid var(--line-100);
+
+  font-size: 20px;
+  font-weight: 400;
+  color: black;
+}
+
+.input.complete {
+  border: 1px solid var(--blue-300);
+}
+.input.invalid {
+  border: 1px solid var(--red-200);
+}
+.input:focus.invalid {
+  border: 1px solid var(--red-200);
+}
+
+.input:focus {
+  border: 1px solid var(--blue-300);
+}
+
+.invaild {
+  display: flex;
+  justify-content: end;
+
+  width: 100%;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--red-200);
+}
+
+.inputContainer {
+  display: flex;
+  width: 100%;
+
+  position: relative;
+}
+
+.iconPill {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+
+  position: absolute;
+  left: 93%;
+  top: 20px;
+}
+.iconPill:hover {
+  background-color: var(--gray-100);
+}

--- a/src/components/page/signup/SignupInput.tsx
+++ b/src/components/page/signup/SignupInput.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import style from './SignupInput.module.css';
+import eyeClose from '../../../assets/icons/ic_eye_close.svg';
+import eyeOpen from '../../../assets/icons/ic_eye_open.svg';
+
+type InputType = {
+  value: string;
+  inputHeandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  validation: boolean;
+};
+
+export const NameInputComponent = ({
+  value,
+  inputHeandler,
+  validation,
+}: InputType) => {
+  return (
+    <div className={style.container}>
+      <span className={style.text}>이름</span>
+      <input
+        className={`${style.input} ${
+          style[value && validation ? 'complete' : '']
+        } ${style[value && !validation ? 'invalid' : '']} `}
+        value={value ?? ''}
+        placeholder='성함을 입력해 주세요.'
+        onChange={inputHeandler}
+        type='text'
+        id='name'
+        name='name'
+      />
+      {validation ? null : (
+        <span className={style.invaild}>
+          2글자 이상, 10자 이하로 입력해주세요.
+        </span>
+      )}
+    </div>
+  );
+};
+
+export const EmailInputComponent = ({
+  value,
+  inputHeandler,
+  validation,
+}: InputType) => {
+  return (
+    <div className={style.container}>
+      <span className={style.text}>이메일</span>
+      <input
+        className={`${style.input} ${
+          style[value && validation ? 'complete' : '']
+        } ${style[value && !validation ? 'invalid' : '']} `}
+        value={value ?? ''}
+        placeholder='이메일을 입력해 주세요.'
+        onChange={inputHeandler}
+        type='text'
+        id='email'
+        name='email'
+      />
+      {validation ? null : (
+        <span className={style.invaild}>이메일 형식이 아닙니다.</span>
+      )}
+    </div>
+  );
+};
+
+export const PhoneNumberInputComponent = ({
+  value,
+  inputHeandler,
+  validation,
+}: InputType) => {
+  return (
+    <div className={style.container}>
+      <span className={style.text}>전화번호</span>
+      <input
+        className={`${style.input} ${
+          style[value && validation ? 'complete' : '']
+        } ${style[value && !validation ? 'invalid' : '']} `}
+        value={value ?? ''}
+        placeholder='숫자만 입력해 주세요.'
+        onChange={inputHeandler}
+        type='text'
+        id='phoneNumber'
+        name='phoneNumber'
+      />
+      {validation ? null : (
+        <span className={style.invaild}>전화번호를 입력해 주세요.</span>
+      )}
+    </div>
+  );
+};
+
+export const PasswordInputComponent = ({
+  value,
+  inputHeandler,
+  validation,
+}: InputType) => {
+  const [invisible, setInvisible] = useState<boolean>(true);
+
+  return (
+    <div className={style.container}>
+      <span className={style.text}>비밀번호</span>
+      <div className={style.inputContainer}>
+        <input
+          value={value ?? ''}
+          onChange={inputHeandler}
+          className={`${style.input} ${
+            style[value && validation ? 'complete' : '']
+          } ${style[value && !validation ? 'invalid' : '']} `}
+          type={invisible ? 'password' : 'text'}
+          id='password'
+          name='password'
+          placeholder='비밀번호을 입력해 주세요.'
+        />
+        <div className={style.iconPill}>
+          {invisible ? (
+            <img
+              onClick={() => {
+                setInvisible((prev) => !prev);
+              }}
+              src={eyeClose}
+              alt=''
+            />
+          ) : (
+            <img
+              onClick={() => {
+                setInvisible((prev) => !prev);
+              }}
+              src={eyeOpen}
+              alt=''
+            />
+          )}
+        </div>
+      </div>
+      {validation ? null : (
+        <span className={style.invaild}>비밀번호가 올바르지 않습니다.</span>
+      )}
+    </div>
+  );
+};
+
+export const ConfirmPasswordInputComponent = ({
+  value,
+  inputHeandler,
+  validation,
+}: InputType) => {
+  const [invisible, setInvisible] = useState<boolean>(true);
+
+  return (
+    <div className={style.container}>
+      <span className={style.text}>비밀번호 확인</span>
+      <div className={style.inputContainer}>
+        <input
+          value={value ?? ''}
+          onChange={inputHeandler}
+          className={`${style.input} ${
+            style[value && validation ? 'complete' : '']
+          } ${style[value && !validation ? 'invalid' : '']} `}
+          type={invisible ? 'password' : 'text'}
+          id='confirmPassword'
+          name='confirmPassword'
+          placeholder='비밀번호을 다시 한번 입력해 주세요.'
+        />
+        <div className={style.iconPill}>
+          {invisible ? (
+            <img
+              onClick={() => {
+                setInvisible((prev) => !prev);
+              }}
+              src={eyeClose}
+              alt=''
+            />
+          ) : (
+            <img
+              onClick={() => {
+                setInvisible((prev) => !prev);
+              }}
+              src={eyeOpen}
+              alt=''
+            />
+          )}
+        </div>
+      </div>
+      {validation ? null : (
+        <span className={style.invaild}>비밀번호가 일치하지 않습니다.</span>
+      )}
+    </div>
+  );
+};

--- a/src/components/page/signup/SignupTop.module.css
+++ b/src/components/page/signup/SignupTop.module.css
@@ -1,0 +1,24 @@
+.top {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: inherit;
+  height: 140px;
+  gap: 18px;
+}
+
+p {
+  font-size: 20px;
+  font-weight: 400;
+}
+
+.top > p > a {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--blue-200);
+
+  box-sizing: border-box;
+  padding-left: 8px;
+}

--- a/src/components/page/signup/SignupTop.tsx
+++ b/src/components/page/signup/SignupTop.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+import style from './SignupTop.module.css';
+import logo from '../../../assets/logo.svg';
+
+export const UserSignupTop = () => {
+  return (
+    <div className={style.top}>
+      <img src={logo} alt='' />
+      <p>
+        기사님이신가요?<Link to='/driver/signup'>기사님 전용 페이지</Link>
+      </p>
+    </div>
+  );
+};
+
+export const DriverSignupTop = () => {
+  return (
+    <div className={style.top}>
+      <img src={logo} alt='' />
+      <p>
+        일반 유저라면?<Link to='/user/signup'>일반 유저 전용 페이지</Link>
+      </p>
+    </div>
+  );
+};

--- a/src/components/page/signup/index.module.css
+++ b/src/components/page/signup/index.module.css
@@ -13,12 +13,12 @@
   justify-content: center;
   align-items: center;
 
-  gap: 72px;
+  gap: 56px;
 
   width: 100%;
   max-width: 640px;
   height: 100%;
-  max-height: 852px;
+  max-height: 1268x;
 
   background-color: white;
 }
@@ -35,7 +35,7 @@ p {
   align-items: center;
 
   width: inherit;
-  height: 432px;
+  height: 966px;
   gap: 56px;
 }
 

--- a/src/lib/function/validation.ts
+++ b/src/lib/function/validation.ts
@@ -19,12 +19,75 @@ export const passwordValidation = (password?: string) => {
   }
 };
 
+export const nameValidation = (name?: string) => {
+  const length = name?.length;
+  //값이 있을 경우에만 유효성 검사 실행.
+  if (length && (length < 2 || length >= 11)) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+export const phoneValidation = (phoneNumber?: string) => {
+  const phoneRegEx = /^(01[016789]{1})[0-9]{4}[0-9]{4}$/;
+  //값이 있을 경우에만 유효성 검사 실행.
+  if (phoneNumber && !phoneRegEx.test(phoneNumber)) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+export const passwordEqualValidation = (
+  confirmPassword?: string,
+  password?: string,
+) => {
+  if (!password && !confirmPassword) {
+    return true;
+  }
+  if (!password) {
+    return false;
+  }
+
+  //값이 있을 경우에만 유효성 검사 실행.
+  if (password && confirmPassword && !(password === confirmPassword)) {
+    return false;
+  } else {
+    return true;
+  } // 비밀번호 일치 여부 검시.
+};
+
+//
 export const loginValidation = (name: string, value?: string) => {
-  if (name === "email") {
+  if (name === 'email') {
     return emailValidation(value);
   }
-  if (name === "password") {
+  if (name === 'password') {
     return passwordValidation(value);
+  }
+  return;
+};
+
+export const signupValidation = (
+  name: string,
+  value?: string,
+  password?: string,
+) => {
+  if (name === 'name') {
+    return nameValidation(value);
+  }
+  if (name === 'email') {
+    return emailValidation(value);
+  }
+  if (name === 'phoneNumber') {
+    return phoneValidation(value);
+  }
+  if (name === 'password') {
+    return passwordValidation(value);
+  }
+  if (name === 'confirmPassword') {
+    return passwordEqualValidation(value, password);
   }
   return;
 };

--- a/src/page/driver/login/index.tsx
+++ b/src/page/driver/login/index.tsx
@@ -9,10 +9,8 @@ import {
   PasswordInputComponent,
 } from '../../../components/page/login/LoginInput';
 import LoginBtn from '../../../components/page/login/LoginBtn';
-import logo from '../../../assets/logo.svg';
-import google from '../../../assets/images/img_login_google_large.svg';
-import kakao from '../../../assets/images/img_login_kakao_large.svg';
-import naver from '../../../assets/images/img_login_naver_large.svg';
+import { DriverLoginTop } from '../../../components/page/login/LoginTop';
+import { DriverLoginBottom } from '../../../components/page/login/LoginBottom';
 
 type FormLogin = {
   email: string;
@@ -60,12 +58,7 @@ export default function DriverLoginPage() {
   return (
     <div className={style.container}>
       <div className={style.wrapper}>
-        <div className={style.top}>
-          <img src={logo} alt='' />
-          <p>
-            일반 유저라면?<Link to='/user/login'>일반 유저 전용 페이지</Link>
-          </p>
-        </div>
+        <DriverLoginTop />
         <div className={style.mid}>
           <form className={style.loginForm} onSubmit={loginSubmit}>
             <EmailInputComponent
@@ -94,14 +87,7 @@ export default function DriverLoginPage() {
             <Link to='/driver/signup'>이메일로 회원가입하기</Link>
           </p>
         </div>
-        <div className={style.bottom}>
-          <span>SNS 계정으로 간편 가입하기</span>
-          <div className={style.snsIcon}>
-            <img src={google} alt='' />
-            <img src={kakao} alt='' />
-            <img src={naver} alt='' />
-          </div>
-        </div>
+        <DriverLoginBottom />
       </div>
     </div>
   );

--- a/src/page/driver/signup/index.tsx
+++ b/src/page/driver/signup/index.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import style from '../../../components/page/signup/index.module.css';
+import { UserSignupBottom } from '../../../components/page/signup/SignupBottom';
+import { DriverSignupTop } from '../../../components/page/signup/SignupTop';
+import { Link } from 'react-router-dom';
+import {
+  EmailInputComponent,
+  PasswordInputComponent,
+} from '../../../components/page/login/LoginInput';
+import { signupValidation } from '../../../lib/function/validation';
+import {
+  ConfirmPasswordInputComponent,
+  NameInputComponent,
+  PhoneNumberInputComponent,
+} from '../../../components/page/signup/SignupInput';
+import SignupBtn from '../../../components/page/signup/SignupBtn';
+
+type FormLogin = {
+  name: string;
+  email: string;
+  phoneNumber: string;
+  password: string;
+  confirmPassword: string;
+};
+
+type FormValidation = {
+  name: boolean;
+  email: boolean;
+  phoneNumber: boolean;
+  password: boolean;
+  confirmPassword: boolean;
+};
+
+export default function DriverSignupPage() {
+  const [values, setValues] = useState<FormLogin>({
+    name: '',
+    email: '',
+    phoneNumber: '',
+    password: '',
+    confirmPassword: '',
+  });
+
+  const [validation, setValidation] = useState<FormValidation>({
+    name: true,
+    email: true,
+    phoneNumber: true,
+    password: true,
+    confirmPassword: true,
+  });
+
+  const inputHeandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.currentTarget;
+    const { password } = values; // 비밀번호 확인 용
+
+    setValues({
+      ...values,
+      [name]: value,
+    });
+
+    setValidation({
+      ...validation,
+      [name]: signupValidation(name, value, password),
+    });
+  };
+
+  const loginSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (
+      !!values.email &&
+      !!values.password &&
+      !!values.name &&
+      !!values.phoneNumber &&
+      !!values.confirmPassword &&
+      validation.email &&
+      validation.password &&
+      validation.name &&
+      validation.phoneNumber &&
+      validation.confirmPassword
+    ) {
+      /**TODO API request */
+    } else {
+      return;
+    }
+  };
+  return (
+    <div className={style.container}>
+      <div className={style.wrapper}>
+        <DriverSignupTop />
+        <div className={style.mid}>
+          <form className={style.loginForm} onSubmit={loginSubmit}>
+            <NameInputComponent
+              value={values.name}
+              inputHeandler={inputHeandler}
+              validation={validation.name}
+            />
+            <EmailInputComponent
+              value={values.email}
+              inputHeandler={inputHeandler}
+              validation={validation.email}
+            />
+            <PhoneNumberInputComponent
+              value={values.phoneNumber}
+              inputHeandler={inputHeandler}
+              validation={validation.phoneNumber}
+            />
+            <PasswordInputComponent
+              value={values.password}
+              inputHeandler={inputHeandler}
+              validation={validation.password}
+            />
+            <ConfirmPasswordInputComponent
+              value={values.confirmPassword}
+              inputHeandler={inputHeandler}
+              validation={validation.confirmPassword}
+            />
+            <SignupBtn
+              context='시작하기'
+              validation={
+                !!values.email &&
+                !!values.password &&
+                !!values.name &&
+                !!values.phoneNumber &&
+                !!values.confirmPassword &&
+                validation.email &&
+                validation.password &&
+                validation.name &&
+                validation.phoneNumber &&
+                validation.confirmPassword
+              }
+            />
+          </form>
+          <p>
+            아직 무빙 회원이 아니신가요?
+            <Link to='/user/signup'>이메일로 회원가입하기</Link>
+          </p>
+        </div>
+        <UserSignupBottom />
+      </div>
+    </div>
+  );
+}

--- a/src/page/driver/signup/index.tsx
+++ b/src/page/driver/signup/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import style from '../../../components/page/signup/index.module.css';
-import { UserSignupBottom } from '../../../components/page/signup/SignupBottom';
+import { DriverSignupBottom } from '../../../components/page/signup/SignupBottom';
 import { DriverSignupTop } from '../../../components/page/signup/SignupTop';
 import { Link } from 'react-router-dom';
 import {
@@ -130,11 +130,11 @@ export default function DriverSignupPage() {
             />
           </form>
           <p>
-            아직 무빙 회원이 아니신가요?
-            <Link to='/user/signup'>이메일로 회원가입하기</Link>
+            이미 무빙 회원이신가요?
+            <Link to='/driver/login'>로그인</Link>
           </p>
         </div>
-        <UserSignupBottom />
+        <DriverSignupBottom />
       </div>
     </div>
   );

--- a/src/page/user/login/index.tsx
+++ b/src/page/user/login/index.tsx
@@ -8,10 +8,8 @@ import {
   EmailInputComponent,
   PasswordInputComponent,
 } from '../../../components/page/login/LoginInput';
-import logo from '../../../assets/logo.svg';
-import google from '../../../assets/images/img_login_google_large.svg';
-import kakao from '../../../assets/images/img_login_kakao_large.svg';
-import naver from '../../../assets/images/img_login_naver_large.svg';
+import { UserLoginTop } from '../../../components/page/login/LoginTop';
+import { UserLoginBottom } from '../../../components/page/login/LoginBottom';
 
 type FormLogin = {
   email: string;
@@ -49,22 +47,22 @@ export default function UserLoginPage() {
 
   const loginSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!(validation.email && validation.password)) {
-      return;
-    } else {
+    if (
+      values.email &&
+      values.password &&
+      validation.email &&
+      validation.password
+    ) {
       /**TODO API request */
+    } else {
+      return;
     }
   };
 
   return (
     <div className={style.container}>
       <div className={style.wrapper}>
-        <div className={style.top}>
-          <img src={logo} alt='' />
-          <p>
-            기사님이신가요?<Link to='/driver/login'>기사님 전용 페이지</Link>
-          </p>
-        </div>
+        <UserLoginTop />
         <div className={style.mid}>
           <form className={style.loginForm} onSubmit={loginSubmit}>
             <EmailInputComponent
@@ -93,14 +91,7 @@ export default function UserLoginPage() {
             <Link to='/user/signup'>이메일로 회원가입하기</Link>
           </p>
         </div>
-        <div className={style.bottom}>
-          <span>SNS 계정으로 간편 가입하기</span>
-          <div className={style.snsIcon}>
-            <img src={google} alt='' />
-            <img src={kakao} alt='' />
-            <img src={naver} alt='' />
-          </div>
-        </div>
+        <UserLoginBottom />
       </div>
     </div>
   );

--- a/src/page/user/signup/index.tsx
+++ b/src/page/user/signup/index.tsx
@@ -130,8 +130,8 @@ export default function UserSignupPage() {
             />
           </form>
           <p>
-            아직 무빙 회원이 아니신가요?
-            <Link to='/user/signup'>이메일로 회원가입하기</Link>
+            이미 무빙 회원이신가요?
+            <Link to='/user/login'>로그인</Link>
           </p>
         </div>
         <UserSignupBottom />

--- a/src/page/user/signup/index.tsx
+++ b/src/page/user/signup/index.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import style from '../../../components/page/signup/index.module.css';
+import { UserSignupBottom } from '../../../components/page/signup/SignupBottom';
+import { UserSignupTop } from '../../../components/page/signup/SignupTop';
+import { Link } from 'react-router-dom';
+import {
+  EmailInputComponent,
+  PasswordInputComponent,
+} from '../../../components/page/login/LoginInput';
+import { signupValidation } from '../../../lib/function/validation';
+import {
+  ConfirmPasswordInputComponent,
+  NameInputComponent,
+  PhoneNumberInputComponent,
+} from '../../../components/page/signup/SignupInput';
+import SignupBtn from '../../../components/page/signup/SignupBtn';
+
+type FormLogin = {
+  name: string;
+  email: string;
+  phoneNumber: string;
+  password: string;
+  confirmPassword: string;
+};
+
+type FormValidation = {
+  name: boolean;
+  email: boolean;
+  phoneNumber: boolean;
+  password: boolean;
+  confirmPassword: boolean;
+};
+
+export default function UserSignupPage() {
+  const [values, setValues] = useState<FormLogin>({
+    name: '',
+    email: '',
+    phoneNumber: '',
+    password: '',
+    confirmPassword: '',
+  });
+
+  const [validation, setValidation] = useState<FormValidation>({
+    name: true,
+    email: true,
+    phoneNumber: true,
+    password: true,
+    confirmPassword: true,
+  });
+
+  const inputHeandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.currentTarget;
+    const { password } = values; // 비밀번호 확인 용
+
+    setValues({
+      ...values,
+      [name]: value,
+    });
+
+    setValidation({
+      ...validation,
+      [name]: signupValidation(name, value, password),
+    });
+  };
+
+  const loginSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (
+      !!values.email &&
+      !!values.password &&
+      !!values.name &&
+      !!values.phoneNumber &&
+      !!values.confirmPassword &&
+      validation.email &&
+      validation.password &&
+      validation.name &&
+      validation.phoneNumber &&
+      validation.confirmPassword
+    ) {
+      /**TODO API request */
+    } else {
+      return;
+    }
+  };
+  return (
+    <div className={style.container}>
+      <div className={style.wrapper}>
+        <UserSignupTop />
+        <div className={style.mid}>
+          <form className={style.loginForm} onSubmit={loginSubmit}>
+            <NameInputComponent
+              value={values.name}
+              inputHeandler={inputHeandler}
+              validation={validation.name}
+            />
+            <EmailInputComponent
+              value={values.email}
+              inputHeandler={inputHeandler}
+              validation={validation.email}
+            />
+            <PhoneNumberInputComponent
+              value={values.phoneNumber}
+              inputHeandler={inputHeandler}
+              validation={validation.phoneNumber}
+            />
+            <PasswordInputComponent
+              value={values.password}
+              inputHeandler={inputHeandler}
+              validation={validation.password}
+            />
+            <ConfirmPasswordInputComponent
+              value={values.confirmPassword}
+              inputHeandler={inputHeandler}
+              validation={validation.confirmPassword}
+            />
+            <SignupBtn
+              context='시작하기'
+              validation={
+                !!values.email &&
+                !!values.password &&
+                !!values.name &&
+                !!values.phoneNumber &&
+                !!values.confirmPassword &&
+                validation.email &&
+                validation.password &&
+                validation.name &&
+                validation.phoneNumber &&
+                validation.confirmPassword
+              }
+            />
+          </form>
+          <p>
+            아직 무빙 회원이 아니신가요?
+            <Link to='/user/signup'>이메일로 회원가입하기</Link>
+          </p>
+        </div>
+        <UserSignupBottom />
+      </div>
+    </div>
+  );
+}

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -4,6 +4,8 @@ import RendingLayout from './layout/RendingLayout';
 import UserLayout from './layout/UserLayout';
 import DriverLoginPage from './page/driver/login';
 import UserLoginPage from './page/user/login';
+import UserSignupPage from './page/user/signup';
+import DriverSignupPage from './page/driver/signup';
 
 const router = createBrowserRouter([
   {
@@ -23,7 +25,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'signup',
-        element: <span>회원가입</span>,
+        element: <UserSignupPage />,
       },
       {
         path: 'costCall',
@@ -54,7 +56,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'signup',
-        element: <span>회원가입</span>,
+        element: <DriverSignupPage />,
       },
       {
         path: 'costCall',


### PR DESCRIPTION
#### 추가사항

- 회원가입 페이지 완성

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- 프로필 수정 페이지 작업
- 로그인, 회원가입, 프로필 수정에서 공통으로 사용되는 컴포넌트로 구조 최적화

#### 테스트 완료 여부

- [ 유효성 검사 로직 ] 테스트 완료

#### 스크린샷

<img width="906" alt="스크린샷 2024-11-28 오후 2 48 04" src="https://github.com/user-attachments/assets/21450a29-f440-4c1a-a015-81dedac81c5a">

<img width="911" alt="스크린샷 2024-11-28 오후 2 49 00" src="https://github.com/user-attachments/assets/dc7d3ebc-000a-41bc-b02d-3c3739ddf45a">

<img width="924" alt="스크린샷 2024-11-28 오후 2 49 54" src="https://github.com/user-attachments/assets/1c282df5-29ae-477d-82ff-5d977c3383ee">

#### 코멘트

유효성 조건 -> 정규식으로 구현했습니다

- 이름 : 2~11 글자수
- 이메일 : 이메일 형식
- 전화번호 : 010을 포함한 8자리 숫자
- 비밀번호 : 특수문자, 영어 대소문자 포함 8자리에서 15자리
- 비밀번호 확인 : 비밀번호 택스트와 동일하게 입력되야 함

