### PR TITLE
[박명준] 공통 컴포넌트 - Tab 구현

### DIFF
--- a/src/components/tab/Tab.module.css
+++ b/src/components/tab/Tab.module.css
@@ -1,0 +1,50 @@
+.container {
+  border-bottom: 1px solid #f2f2f2;
+}
+
+.select {
+  display: flex;
+  align-items: flex-end;
+  gap: 32px;
+
+  width: 100%;
+  max-width: 1400px;
+  height: 88px;
+
+  margin: 0 auto;
+}
+
+.selectedContent {
+  padding: 16px 0;
+
+  font-weight: 600;
+  font-size: 20px;
+
+  color: var(--gray-400);
+
+  cursor: pointer;
+}
+
+.active {
+  border-bottom: 2px solid var(--black-400);
+
+  color: var(--black-400);
+}
+
+.nonSelect {
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  max-width: 1400px;
+  height: 96px;
+
+  margin: 0 auto;
+}
+
+.content {
+  font-weight: 600;
+  font-size: 24px;
+  color: var(--black-400);
+}
+

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -1,0 +1,62 @@
+import classNames from 'classnames';
+import styles from './Tab.module.css';
+
+interface TabProps {
+  selectable?: boolean;
+  firstText: string;
+  secondText?: string;
+  selectedTab?: 'first' | 'second';
+  onTabChange?: (selectedTab: 'first' | 'second') => void;
+  tabChangeType?: 'state' | 'route';
+  firstTabRoute?: () => void;
+  secondTabRoute?: () => void;
+}
+
+export default function Tab({
+  selectable = false,
+  firstText,
+  secondText,
+  selectedTab,
+  onTabChange,
+  tabChangeType = 'state',
+  firstTabRoute,
+  secondTabRoute,
+}: TabProps) {
+  const handleTabClick = (tab: 'first' | 'second') => {
+    if (tabChangeType === 'state') {
+      onTabChange?.(tab);
+    } else if (tabChangeType === 'route') {
+      if (tab === 'first') {
+        firstTabRoute?.();
+      } else {
+        secondTabRoute?.();
+      }
+    }
+  };
+
+  const renderTab = (tab: 'first' | 'second', text: string | undefined) => (
+    <div
+      className={classNames(styles.selectedContent, {
+        [styles.active]: selectedTab === tab,
+      })}
+      onClick={() => handleTabClick(tab)}
+    >
+      {text}
+    </div>
+  );
+
+  return (
+    <div className={styles.container}>
+      {selectable ? (
+        <div className={styles.select}>
+          {renderTab('first', firstText)}
+          {renderTab('second', secondText)}
+        </div>
+      ) : (
+        <div className={styles.nonSelect}>
+          <div className={styles.content}>{firstText}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/function/direction.ts
+++ b/src/lib/function/direction.ts
@@ -1,19 +1,33 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from 'react-router-dom';
 
 export default function useDirection() {
   const nav = useNavigate();
 
   const direction_root = () => {
-    nav("/");
+    nav('/');
   };
 
   const direction_searchDriver = () => {
-    nav("/searchDriver");
+    nav('/searchDriver');
   };
 
   const direction_userLogin = () => {
-    nav("/user/login");
+    nav('/user/login');
   };
 
-  return { direction_root, direction_searchDriver, direction_userLogin };
+  const direction_pendingCost = () => {
+    nav('/user/pendingCost');
+  };
+
+  const direction_receivedCost = () => {
+    nav('/user/receivedCost');
+  };
+
+  return {
+    direction_root,
+    direction_searchDriver,
+    direction_userLogin,
+    direction_pendingCost,
+    direction_receivedCost,
+  };
 }

--- a/src/page/user/favoriteMover/index.module.css
+++ b/src/page/user/favoriteMover/index.module.css
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+  height: 100%;
+
+  min-width: 100vw;
+  min-height: 100vh;
+}

--- a/src/page/user/favoriteMover/index.tsx
+++ b/src/page/user/favoriteMover/index.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import Tab from '../../../components/tab/Tab';
+import styles from './index.module.css';
+
+export default function UserFavoriteMover() {
+  const [currentTab, setCurrentTab] = useState<'first' | 'second'>('first');
+
+  const handleTabChange = (selectedTab: 'first' | 'second') => {
+    setCurrentTab(selectedTab);
+  };
+
+  return (
+    <div className={styles.container}>
+      <Tab
+        selectable={true}
+        firstText='작성 가능한 리뷰'
+        secondText='내가 작성한 리뷰'
+        selectedTab={currentTab}
+        onTabChange={handleTabChange}
+      />
+      {currentTab === 'first' ? (
+        <div>작성 가능한 리뷰</div>
+      ) : (
+        <div>내가 작성한 리뷰</div>
+      )}
+    </div>
+  );
+}

--- a/src/page/user/pendingCost/index.module.css
+++ b/src/page/user/pendingCost/index.module.css
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+  height: 100%;
+
+  min-width: 100vw;
+  min-height: 100vh;
+}

--- a/src/page/user/pendingCost/index.tsx
+++ b/src/page/user/pendingCost/index.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import Tab from '../../../components/tab/Tab';
+import styles from './index.module.css';
+import useDirection from '../../../lib/function/direction';
+
+export default function PendingCost() {
+  const [currentTab, setCurrentTab] = useState<'first' | 'second'>('first');
+
+  const handleTabChange = (selectedTab: 'first' | 'second') => {
+    setCurrentTab(selectedTab);
+  };
+
+  const { direction_pendingCost, direction_receivedCost } = useDirection();
+  return (
+    <div className={styles.container}>
+      <Tab
+        selectable={true}
+        firstText='대기 중인 견적'
+        secondText='받았던 견적'
+        selectedTab={currentTab}
+        onTabChange={handleTabChange}
+        tabChangeType='route'
+        firstTabRoute={direction_pendingCost}
+        secondTabRoute={direction_receivedCost}
+      />
+      <div>대기 중인 견적</div>
+    </div>
+  );
+}

--- a/src/page/user/receivedCost/index.module.css
+++ b/src/page/user/receivedCost/index.module.css
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+  height: 100%;
+
+  min-width: 100vw;
+  min-height: 100vh;
+}

--- a/src/page/user/receivedCost/index.tsx
+++ b/src/page/user/receivedCost/index.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import Tab from '../../../components/tab/Tab';
+import styles from './index.module.css';
+import useDirection from '../../../lib/function/direction';
+
+export default function ReceivedCost() {
+  const [currentTab, setCurrentTab] = useState<'first' | 'second'>('second');
+
+  const handleTabChange = (selectedTab: 'first' | 'second') => {
+    setCurrentTab(selectedTab);
+  };
+
+  const { direction_pendingCost, direction_receivedCost } = useDirection();
+  return (
+    <div className={styles.container}>
+      <Tab
+        selectable={true}
+        firstText='대기 중인 견적'
+        secondText='받았던 견적'
+        selectedTab={currentTab}
+        onTabChange={handleTabChange}
+        tabChangeType='route'
+        firstTabRoute={direction_pendingCost}
+        secondTabRoute={direction_receivedCost}
+      />
+      <div>받았던 견적</div>
+    </div>
+  );
+}

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -1,9 +1,12 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Outlet } from 'react-router-dom';
 import DriverLayout from './layout/DriverLayout';
 import RendingLayout from './layout/RendingLayout';
 import UserLayout from './layout/UserLayout';
 import DriverLoginPage from './page/driver/login';
 import UserLoginPage from './page/user/login';
+import UserFavoriteMover from './page/user/favoriteMover';
+import PendingCost from './page/user/pendingCost';
+import ReceivedCost from './page/user/receivedCost';
 
 const router = createBrowserRouter([
   {
@@ -34,8 +37,21 @@ const router = createBrowserRouter([
         element: <span>기사님 찾기</span>,
       },
       {
-        path: 'constHandler',
-        element: <span>내 견적 관리</span>,
+        element: <Outlet />,
+        children: [
+          {
+            path: 'pendingCost',
+            element: <PendingCost />,
+          },
+          {
+            path: 'receivedCost',
+            element: <ReceivedCost />,
+          },
+        ],
+      },
+      {
+        path: 'favoriteMover',
+        element: <UserFavoriteMover />,
       },
       {
         path: 'profile',


### PR DESCRIPTION
#### 추가사항

- route 설정
-  Tab 공통 컴포넌트 추가

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- 아직 반응형(미디어 쿼리)은 진행하지 않았습니다! Nav와 디자인이 흡사해 Nav 디자인 후 규격에 맞게 디자인하겠습니다!
- 찜한 기사님 페이지 진행 예정

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷

단일 타이틀로 쓰는 경우 입니다.

![](https://velog.velcdn.com/images/pmj9498/post/fceb307f-c27d-43b8-99ba-483a764275ec/image.png)

```tsx
// 사용 예시 (간단함)
<Tab firstText='찜한 기사님' />
```
---

![](https://velog.velcdn.com/images/pmj9498/post/9ca34317-66d0-472d-930f-efae4c148c99/image.png)

```tsx
// 사용 예시
const [currentTab, setCurrentTab] = useState<'first' | 'second'>('first');

  const handleTabChange = (selectedTab: 'first' | 'second') => {
    setCurrentTab(selectedTab);
  };
// ...
	<Tab
        selectable={true}
        firstText='작성 가능한 리뷰'
        secondText='내가 작성한 리뷰'
        selectedTab={currentTab}
        onTabChange={handleTabChange}
      />
      {currentTab === 'first' ? (
        <div>작성 가능한 리뷰</div>
      ) : (
        <div>내가 작성한 리뷰</div>
      )}
```

#### 코멘트

라우트로 탭 이동하는 대기 중인 견적과 받았던 견적은 Tab을 다 넣어서 페이지 생성하여 예시는 넘어가겠습니다!
이상한 부분 말씀해주시면 바로 수정하겠습니다.