### PR TITLE
[김민서] 공통 경로 - 내 견적 관리 페이지 관련 모든 임시 경로 추가

### DIFF
--- a/src/root.tsx
+++ b/src/root.tsx
@@ -78,6 +78,29 @@ const router = createBrowserRouter([
         path: 'resister',
         element: <UserResisterPage />,
       },
+      // 새로 추가된 "내 견적 관리" 관련 경로들
+      {
+        path: 'costHandler',
+        element: <span>내 견적 관리</span>, // 메인 페이지
+        children: [
+          {
+            path: 'waiting',
+            element: <span>대기 중인 견적</span>, // 대기 중인 견적 페이지
+          },
+          {
+            path: 'waiting/:id',
+            element: <span>대기 중인 견적 상세</span>, // 대기 중인 견적 상세 페이지
+          },
+          {
+            path: 'received',
+            element: <span>받았던 견적</span>, // 받았던 견적 페이지
+          },
+          {
+            path: 'received/:id',
+            element: <span>받았던 견적 상세</span>, // 받았던 견적 상세 페이지
+          },
+        ],
+      },
     ],
   },
   {
@@ -121,3 +144,4 @@ const router = createBrowserRouter([
 ]);
 
 export default router;
+

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -81,8 +81,12 @@ const router = createBrowserRouter([
       // 새로 추가된 "내 견적 관리" 관련 경로들
       {
         path: 'costHandler',
-        element: <span>내 견적 관리</span>, // 메인 페이지
+        element: <span>내 견적 관리</span>,
         children: [
+          {
+            index: true, // 기본 경로 설정
+            element: <span>대기 중인 견적</span>, // 기본으로 "대기 중인 견적" 페이지를 렌더링
+          },
           {
             path: 'waiting',
             element: <span>대기 중인 견적</span>, // 대기 중인 견적 페이지
@@ -144,4 +148,3 @@ const router = createBrowserRouter([
 ]);
 
 export default router;
-


### PR DESCRIPTION
#### 추가사항

- [x] 내 견적 관리 관련 임시 경로( `span` )를 추가했습니다.

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ] 내 견적 관리 페이지

#### 테스트 완료 여부

- [ ] 테스트 완료

#### 스크린샷


#### 코멘트
- 현재는 `span` 태그로 처리되어 있으며, 이후 실제 페이지 컴포넌트가 구현되면 해당 경로에서 `span` 태그를 해당 컴포넌트로 교체해야 합니다.
- `/user/costHandler` 경로는 기본적으로 **내 견적 관리_대기 중인 견적 페이지**를 렌더링합니다.
- 추가된 경로:
  - `/user/costHandler`: 기본 경로, **대기 중인 견적 페이지**
  - `/user/costHandler/waiting`: **대기 중인 견적 페이지** @mjpark-k 
  - `/user/costHandler/waiting/:id`: **대기 중인 견적 상세 페이지** @claudia99503 
  - `/user/costHandler/received`: **받았던 견적 목록 페이지** @mozzi34 
  - `/user/costHandler/received/:id`: **받았던 견적 상세 페이지** @claudia99503 


```
// 새로 추가된 "내 견적 관리" 관련 경로들
      {
        path: 'costHandler',
        element: <span>내 견적 관리</span>,
        children: [
          {
            index: true, // 기본 경로 설정
            element: <span>대기 중인 견적</span>, // 기본으로 "대기 중인 견적" 페이지를 렌더링
          },
          {
            path: 'waiting',
            element: <span>대기 중인 견적</span>, // 대기 중인 견적 페이지
          },
          {
            path: 'waiting/:id',
            element: <span>대기 중인 견적 상세</span>, // 대기 중인 견적 상세 페이지
          },
          {
            path: 'received',
            element: <span>받았던 견적</span>, // 받았던 견적 페이지
          },
          {
            path: 'received/:id',
            element: <span>받았던 견적 상세</span>, // 받았던 견적 상세 페이지
          },
        ],
      },
```
