### PR TITLE
[김민서] 기사님 찾기 페이지 - 목데이터 및 기사님 프로필 카드 추가

### DIFF
--- a/src/components/card/DriverCard.module.css
+++ b/src/components/card/DriverCard.module.css
@@ -162,7 +162,7 @@
 
 @media (max-width: 1199px) {
   .card {
-    max-width: 955px;
+    width: 100%;
     padding: 16px 14px;
     gap: 14px;
   }

--- a/src/components/card/DriverCard.tsx
+++ b/src/components/card/DriverCard.tsx
@@ -28,12 +28,12 @@ const chipText = (type: string): ChipType => {
 };
 
 export default function DriverCard({
-  editInfoBtn,
-  editProfileBtn,
-  confirmCostBtn,
-  detailBtn,
-  reviewBtn,
-  costListBtn,
+  editInfoBtn, // 기본 정보 수정 버튼
+  editProfileBtn, // 기본 정보 내 프로필 수정
+  confirmCostBtn, // 견적 확정하기 버튼
+  detailBtn, // 상세보기 버튼
+  reviewBtn, // 리뷰 작성하기 버튼
+  costListBtn, // 견적 목록하기 버튼
   type,
   user,
   onClick, // onClick prop 추가

--- a/src/components/card/DriverCard.tsx
+++ b/src/components/card/DriverCard.tsx
@@ -1,15 +1,12 @@
+import React from 'react';
 import classNames from 'classnames';
-
 import DriverProfile from './DriverProfile';
 import Button from '../btn/Button';
 import Chip from '../chip/Chip';
-
 import { useMedia } from '../../lib/function/useMediaQuery';
 import { formatCurrency } from '../../lib/function/utils';
 import { DriverProfileProps } from './type';
-
 import style from './DriverCard.module.css';
-
 import writing from '../../assets/icons/ic_writing_medium.svg';
 import writingGray from '../../assets/icons/ic_writing_gray.svg';
 
@@ -31,15 +28,16 @@ const chipText = (type: string): ChipType => {
 };
 
 export default function DriverCard({
-  editInfoBtn, //기본 정보 수정 버튼
-  editProfileBtn, //기본 정보 내 프로필 수정
-  confirmCostBtn, //견적 확정하기 버튼
-  detailBtn, //상세보기 버튼
-  reviewBtn, //리뷰 작성하기 버튼
-  costListBtn, //견적 목록보기 버튼
+  editInfoBtn,
+  editProfileBtn,
+  confirmCostBtn,
+  detailBtn,
+  reviewBtn,
+  costListBtn,
   type,
   user,
-}: DriverProfileProps) {
+  onClick, // onClick prop 추가
+}: DriverProfileProps & { onClick?: () => void }) {
   const isPc = useMedia().pc;
 
   return (
@@ -47,6 +45,7 @@ export default function DriverCard({
       className={classNames(style.card, {
         [style.cardPType]: type === 'profile',
       })}
+      onClick={onClick} // 최상단 div에 onClick 이벤트 추가
     >
       {type === 'profile' ? (
         <div className={style.topPType}>
@@ -83,7 +82,7 @@ export default function DriverCard({
           {user.serviceType?.map((type, index) => (
             <Chip key={index} type={chipText(type)} />
           ))}
-          {(user.isAssigned) && <Chip type='ASSIGN' />}
+          {user.isAssigned && <Chip type='ASSIGN' />}
         </div>
       )}
       {(type === 'cost' || type === undefined) && (
@@ -138,8 +137,8 @@ export default function DriverCard({
             {type === 'notConfirm'
               ? '미확정'
               : type === 'cancel'
-                ? '취소'
-                : user.price && formatCurrency(user.price)}
+              ? '취소'
+              : user.price && formatCurrency(user.price)}
           </div>
           <div className={style.costBtn}>
             {type === 'waiting' && (
@@ -178,3 +177,4 @@ export default function DriverCard({
     </div>
   );
 }
+

--- a/src/page/root/searchDriver/components/DriverSearch.tsx
+++ b/src/page/root/searchDriver/components/DriverSearch.tsx
@@ -1,22 +1,24 @@
+import React, { ChangeEvent } from 'react';
 import style from './DriverSearch.module.css';
 
 interface DriverSearchProps {
   placeholder: string;
   className?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-const DriverSearch = ({ placeholder, className }: DriverSearchProps) => {
+const DriverSearch = ({ placeholder, className, onChange }: DriverSearchProps) => {
   return (
     <div className={`${style.searchContainer} ${className || ''}`}>
-      <img alt='Search Icon' className={style.searchIcon} />
+      <img alt="Search Icon" className={style.searchIcon} />
       <input
-        type='text'
+        type="text"
         placeholder={placeholder}
         className={style.searchInput}
+        onChange={onChange}
       />
     </div>
   );
 };
 
 export default DriverSearch;
-

--- a/src/page/root/searchDriver/index.module.css
+++ b/src/page/root/searchDriver/index.module.css
@@ -56,13 +56,20 @@
   line-height: 32px;
   color: #1f1f1f;
   margin-top: 46px;
-  margin-bottom: 16px;
+}
+
+.favoriteDriversContainer {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .rightFilters {
   align-items: flex-end;
   max-width: 955px;
   flex: 1;
+  position: relative;
 }
 
 .sortDropdown {
@@ -78,7 +85,34 @@
   border-radius: 8px;
 }
 
-@media (max-width: 1199px) and (min-width: 745px) {
+.cardContainer {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  width: 100%;
+}
+
+.cardContainer.rightFilters {
+  margin-top: 0;
+  gap: 48px;
+}
+
+.cardContainer.compact {
+  margin-top: 24px;
+  gap: 30px;
+}
+
+.cardContainer.smallScreen {
+  margin-top: 24px;
+  gap: 24px;
+}
+
+.cardSpacing {
+  margin-top: 48px;
+}
+
+@media (max-width: 1199px) and (min-width: 744px) {
   .container {
     padding: 20px 72px;
   }
@@ -86,15 +120,33 @@
   .filterRow {
     gap: 20px;
   }
+
+  .cardContainer.compact {
+    margin-top: 24px;
+    gap: 30px;
+  }
+
+  .cardSpacing {
+    margin-top: 32px;
+  }
 }
 
-@media (max-width: 744px) and (min-width: 375px) {
+@media (max-width: 743px) and (min-width: 375px) {
   .container {
     padding: 20px 24px;
   }
 
   .filterRow {
     gap: 20px;
+  }
+
+  .cardContainer.smallScreen {
+    margin-top: 24px;
+    gap: 24px;
+  }
+
+  .cardSpacing {
+    margin-top: 24px;
   }
 }
 

--- a/src/page/root/searchDriver/index.tsx
+++ b/src/page/root/searchDriver/index.tsx
@@ -4,6 +4,7 @@ import FilterDropdown from './components/FilterDropdown';
 import FilterDropdownMedium from './components/FilterDropdownMedium';
 import SortDropdown from './components/SortDropdown';
 import DriverSearch from './components/DriverSearch';
+import DriverCard from '../../../components/card/DriverCard';
 import style from './index.module.css';
 import { translations, REGION_ITEMS, SERVICE_ITEMS } from '../searchDriver/utils/Constants';
 
@@ -20,40 +21,151 @@ const SORT_OPTIONS = [
   { label: '확정 많은순', value: 'confirmationCount' },
 ];
 
+const MOCK_DATA = [
+    {
+      id: 1,
+      nickname: '유재석',
+      profileImage: 'https://via.placeholder.com/150',
+      summary: '유쾌함과 전문성을 갖춘 15년 경력의 이사 전문가입니다.',
+      reviewStats: { averageScore: 4.9, totalReviews: 80 },
+      price: 140000,
+      serviceRegion: ['서울', '경기'],
+      serviceType: ['가정이사'],
+      isAssigned: false,
+      career: 15,
+      confirmationCount: 55,
+      favoriteCount: 200,
+      isLiked: true,
+    },
+    {
+      id: 2,
+      nickname: '강호동',
+      profileImage: 'https://via.placeholder.com/150',
+      summary: '강력한 체력과 노련함으로 20년간 사무실 이사를 책임졌습니다.',
+      reviewStats: { averageScore: 4.7, totalReviews: 60 },
+      price: 180000,
+      serviceRegion: ['부산', '울산'],
+      serviceType: ['사무실이사'],
+      isAssigned: false,
+      career: 20,
+      confirmationCount: 90,
+      favoriteCount: 150,
+      isLiked: false,
+    },
+    {
+      id: 3,
+      nickname: '손예진',
+      profileImage: 'https://via.placeholder.com/150',
+      summary: '세심함이 강점인 12년 경력의 소형 이사 전문가입니다.',
+      reviewStats: { averageScore: 4.8, totalReviews: 50 },
+      price: 130000,
+      serviceRegion: ['인천', '서울'],
+      serviceType: ['소형이사'],
+      isAssigned: true,
+      career: 12,
+      confirmationCount: 30,
+      favoriteCount: 250,
+      isLiked: true,
+    },
+    {
+      id: 4,
+      nickname: '현빈',
+      profileImage: 'https://via.placeholder.com/150',
+      summary: '8년 경력으로 전국 어디든 빠르고 안전하게 이사합니다.',
+      reviewStats: { averageScore: 4.5, totalReviews: 40 },
+      price: 100000,
+      serviceRegion: ['전국'],
+      serviceType: ['가정이사', '소형이사'],
+      isAssigned: false,
+      career: 8,
+      confirmationCount: 15,
+      favoriteCount: 120,
+      isLiked: false,
+    },
+    {
+      id: 5,
+      nickname: '차은우',
+      profileImage: 'https://via.placeholder.com/150',
+      summary: '고객 만족을 최우선으로 하는 5년 경력의 이사 전문가입니다.',
+      reviewStats: { averageScore: 4.6, totalReviews: 30 },
+      price: 110000,
+      serviceRegion: ['대구', '경북'],
+      serviceType: ['가정이사'],
+      isAssigned: true,
+      career: 5,
+      confirmationCount: 75,
+      favoriteCount: 300,
+      isLiked: true,
+    },
+  ];
+
 const SearchDriverForGuest = () => {
   const [openFilter, setOpenFilter] = useState<string | null>(null);
   const [selectedRegionLabel, setSelectedRegionLabel] = useState<string>('지역');
   const [selectedServiceLabel, setSelectedServiceLabel] = useState<string>('서비스');
-  const [selectedServiceRegion, setSelectedServiceRegion] = useState<string>('');
-  const [selectedServiceType, setSelectedServiceType] = useState<string>('');
+  const [searchKeyword, setSearchKeyword] = useState<string>(''); // 검색 상태
+  const [sortOption, setSortOption] = useState<string>('reviewCount'); // 정렬 상태
+  const [filteredData, setFilteredData] = useState(MOCK_DATA); // 필터링된 데이터 상태
   const [isMediumScreen, setIsMediumScreen] = useState<boolean>(window.innerWidth <= 1199);
+  const [isSmallScreen, setIsSmallScreen] = useState<boolean>(window.innerWidth <= 744);
 
   useEffect(() => {
-    const handleResize = () => setIsMediumScreen(window.innerWidth <= 1199);
+    const handleResize = () => {
+      setIsMediumScreen(window.innerWidth <= 1199);
+      setIsSmallScreen(window.innerWidth <= 744);
+    };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const sendToServer = (region: string, service: string, sort: string) => {
-    const payload = { selectedServiceRegion: region, selectedServiceType: service, sortBy: sort };
-    console.log('서버로 전송할 데이터:', payload);
+  useEffect(() => {
+    let data = MOCK_DATA;
+
+    if (selectedRegionLabel !== '지역') {
+      data = data.filter((driver) =>
+        driver.serviceRegion.includes(translations[selectedRegionLabel])
+      );
+    }
+
+    if (selectedServiceLabel !== '서비스') {
+      data = data.filter((driver) =>
+        driver.serviceType.includes(translations[selectedServiceLabel])
+      );
+    }
+
+    if (searchKeyword) {
+      data = data.filter((driver) =>
+        driver.nickname.includes(searchKeyword) || driver.summary.includes(searchKeyword)
+      );
+    }
+
+    if (sortOption) {
+      data = [...data].sort((a, b) => {
+        if (sortOption === 'reviewCount') return b.reviewStats.totalReviews - a.reviewStats.totalReviews;
+        if (sortOption === 'averageScore') return b.reviewStats.averageScore - a.reviewStats.averageScore;
+        if (sortOption === 'career') return b.career - a.career;
+        if (sortOption === 'confirmationCount') return b.confirmationCount - a.confirmationCount;
+        return 0;
+      });
+    }
+
+    setFilteredData(data);
+  }, [selectedRegionLabel, selectedServiceLabel, searchKeyword, sortOption]);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(e.target.value);
   };
 
   const handleSelect = (type: string, label: string) => {
-    const value = translations[label] || '';
     if (type === FILTER_TYPES.REGION) {
       setSelectedRegionLabel(label);
-      setSelectedServiceRegion(value);
-      sendToServer(value, selectedServiceType, 'reviewCount');
     } else if (type === FILTER_TYPES.SERVICE) {
       setSelectedServiceLabel(label);
-      setSelectedServiceType(value);
-      sendToServer(selectedServiceRegion, value, 'reviewCount');
     }
   };
 
   const handleSortSelect = (value: string) => {
-    sendToServer(selectedServiceRegion, selectedServiceType, value);
+    setSortOption(value);
   };
 
   const handleToggleFilter = (filterName: string) => {
@@ -90,6 +202,26 @@ const SearchDriverForGuest = () => {
     </>
   );
 
+  const renderDriverCards = () => (
+    <div
+      className={`${style.cardContainer} ${
+        isMediumScreen ? (isSmallScreen ? style.smallScreen : style.compact) : style.rightFilters
+      }`}
+    >
+      {filteredData.map((user) => (
+        <DriverCard key={user.id} user={user} />
+      ))}
+    </div>
+  );
+
+  const renderFavoriteDrivers = () => (
+    <div className={style.favoriteDriversContainer}>
+      {MOCK_DATA.map((user) => (
+        <DriverCard key={user.id} user={user} type="dibs" />
+      ))}
+    </div>
+  );
+
   return (
     <div className={style.outerContainer}>
       <div className={style.noPadding}>
@@ -120,6 +252,7 @@ const SearchDriverForGuest = () => {
                   onToggle={() => handleToggleFilter(FILTER_TYPES.SERVICE)}
                 />
                 <div className={style.favoriteDrivers}>찜한 기사님</div>
+                {renderFavoriteDrivers()}
               </div>
               <div className={style.rightFilters}>
                 <SortDropdown
@@ -129,16 +262,18 @@ const SearchDriverForGuest = () => {
                   onToggle={() => handleToggleFilter(FILTER_TYPES.SORT)}
                   onSelect={handleSortSelect}
                 />
-                {!isMediumScreen && <DriverSearch placeholder="검색어를 입력하세요" />}
+                {!isMediumScreen && <DriverSearch placeholder="검색어를 입력하세요" onChange={handleSearchChange} />}
+                {!isMediumScreen && renderDriverCards()}
               </div>
             </>
           )}
         </div>
         {isMediumScreen && (
           <div className={style.searchBarCompact}>
-            <DriverSearch placeholder="검색어를 입력하세요" />
+            <DriverSearch placeholder="검색어를 입력하세요" onChange={handleSearchChange} />
           </div>
         )}
+        {isMediumScreen && renderDriverCards()}
       </div>
     </div>
   );


### PR DESCRIPTION
#### 추가사항
#46 
- [x] 목데이터 추가
- [x] 기사님 프로필 카드 추가

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- 기사님 상세 페이지

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷

### **데스크탑**
![image](https://github.com/user-attachments/assets/88e78702-5eb3-4ec4-b931-aed34957f1c4)

### **태블릿**
![image](https://github.com/user-attachments/assets/ab2715db-b12d-478c-a674-95c5e34870ed)

### **모바일**
![image](https://github.com/user-attachments/assets/21174e89-0299-4295-a147-5d7f1ca01ef5)


#### 코멘트
- 찜한 기사님 프로필 카드( `CSS` ) 수정 요청
   - `모바일` 화면 크기가 375~743px 일때
   - 찜한 기사님만 있는 페이지에서는 모바일 기준으로 **찜한 기사님의 프로필 카드** 최소 넓이가 327px  
   - => 기사님 찾기 페이지에서는 **찜한 기사님의 프로필 카드** max-width가 328px라서 글씨가 다 튀어나오는 문제 발생 (카드 자체는 문제 X, 프로필 이미지, 글씨들만)