### PR TITLE
[김민서] 백엔드 필드명에 맞춰 목 데이터 및 컴포넌트 수정

### DIFF
--- a/src/components/card/type.ts
+++ b/src/components/card/type.ts
@@ -1,4 +1,4 @@
-export type ChipType = 'SMALL' | 'HOME' | 'COMPANY' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
+export type ChipType = 'SMALL' | 'HOUSE' | 'OFFICE' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
 
 // DriverCard, DriverProfile
 export type DriverProfileType =

--- a/src/components/chip/Chip.tsx
+++ b/src/components/chip/Chip.tsx
@@ -10,8 +10,8 @@ import icCompanyMedium from '../../assets/icons/ic_company_medium.svg';
 import icDocumentLarge from '../../assets/icons/ic_document_large.svg';
 import icDocumentMedium from '../../assets/icons/ic_document_medium.svg';
 
-interface ChipProps {
-  type: 'SMALL' | 'HOME' | 'COMPANY' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
+export interface ChipProps {
+  type: 'SMALL' | 'HOUSE' | 'OFFICE' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
 }
 
 export default function Chip({ type }: ChipProps) {
@@ -21,9 +21,9 @@ export default function Chip({ type }: ChipProps) {
     switch (type) {
       case 'SMALL':
         return pc ? icBoxLarge : icBoxMedium;
-      case 'HOME':
+      case 'HOUSE':
         return pc ? icHomeLarge : icHomeMedium;
-      case 'COMPANY':
+      case 'OFFICE':
         return pc ? icCompanyLarge : icCompanyMedium;
       case 'ASSIGN':
         return pc ? icDocumentLarge : icDocumentMedium;
@@ -36,9 +36,9 @@ export default function Chip({ type }: ChipProps) {
     switch (type) {
       case 'SMALL':
         return '소형이사';
-      case 'HOME':
+      case 'HOUSE':
         return '가정이사';
-      case 'COMPANY':
+      case 'OFFICE':
         return '사무실이사';
       case 'ASSIGN':
         return '지정 견적 요청';

--- a/src/page/driver/costCall/components/mockData.ts
+++ b/src/page/driver/costCall/components/mockData.ts
@@ -37,7 +37,7 @@ export const mockData: UserData = {
     },
     {
       id: 2,
-      movingType: ['HOME'],
+      movingType: ['HOUSE'],
       isAssigned: true,
       customer: 'user2',
       movingDate: '2024.07.15',
@@ -47,7 +47,7 @@ export const mockData: UserData = {
     },
     {
       id: 3,
-      movingType: ['COMPANY'],
+      movingType: ['OFFICE'],
       isAssigned: false,
       customer: 'user3',
       movingDate: '2024.08.01',
@@ -67,7 +67,7 @@ export const mockData: UserData = {
     },
     {
       id: 5,
-      movingType: ['HOME'],
+      movingType: ['HOUSE'],
       isAssigned: false,
       customer: 'user5',
       movingDate: '2024.07.25',
@@ -77,7 +77,7 @@ export const mockData: UserData = {
     },
     {
       id: 6,
-      movingType: ['COMPANY'],
+      movingType: ['OFFICE'],
       isAssigned: true,
       customer: 'user6',
       movingDate: '2024.08.10',
@@ -97,7 +97,7 @@ export const mockData: UserData = {
     },
     {
       id: 8,
-      movingType: ['HOME'],
+      movingType: ['HOUSE'],
       isAssigned: false,
       customer: 'user8',
       movingDate: '2024.08.20',
@@ -107,7 +107,7 @@ export const mockData: UserData = {
     },
     {
       id: 9,
-      movingType: ['COMPANY'],
+      movingType: ['OFFICE'],
       isAssigned: true,
       customer: 'user9',
       movingDate: '2024.09.05',

--- a/src/page/driver/costHandler/mockData.ts
+++ b/src/page/driver/costHandler/mockData.ts
@@ -29,7 +29,7 @@ export const mockData: DriverData = {
     // 확정된 견적 요청일 때
     {
       id: 1,
-      serviceType: ['SMALL', 'COMPANY'],
+      serviceType: ['SMALL', 'OFFICE'],
       isConfirmed: true,
       isCancelled: false,
       isAssigned: true,
@@ -51,7 +51,7 @@ export const mockData: DriverData = {
     // 확정되지 않은 견적 요청일 때
     {
       id: 2,
-      serviceType: ['HOME'],
+      serviceType: ['HOUSE'],
       isConfirmed: false,
       isCancelled: false,
       isAssigned: true,
@@ -73,7 +73,7 @@ export const mockData: DriverData = {
     // 확정된 견적 요청일 때
     {
       id: 3,
-      serviceType: ['COMPANY'],
+      serviceType: ['OFFICE'],
       isConfirmed: true,
       isCancelled: false,
       isAssigned: false,

--- a/src/page/root/DriverDetailPage.tsx
+++ b/src/page/root/DriverDetailPage.tsx
@@ -3,11 +3,17 @@ import { useParams } from 'react-router-dom';
 import style from './DriverDetail.module.css';
 import DriverCard from '../../components/card/DriverCard';
 import { MOCK_DATA } from '../root/searchDriver/mockData';
-import { translateServiceRegion, translateServiceType } from '../root/searchDriver/EnumMapper';
+import { ChipProps } from '../../components/chip/Chip';
+import {
+  translateServiceRegion,
+  translateServiceType,
+} from './searchDriver/EnumMapper';
 
 const DriverDetailPage = () => {
   const { id } = useParams<{ id: string }>(); // URL에서 기사님 ID 가져오기
-  const driver = MOCK_DATA.find((driver) => driver.id === parseInt(id || '', 10)); // ID로 기사 찾기
+  const driver = MOCK_DATA.find(
+    (driver) => driver.id === parseInt(id || '', 10),
+  ); // ID로 기사 찾기
 
   if (!driver) {
     return (
@@ -17,11 +23,9 @@ const DriverDetailPage = () => {
     );
   }
 
-  // EnumMapper를 이용해 데이터를 한글로 변환
   const transformedDriver = {
     ...driver,
-    serviceRegion: driver.serviceRegion.map(translateServiceRegion),
-    serviceType: driver.serviceType.map(translateServiceType),
+    serviceType: driver.serviceType.map((type) => type as ChipProps['type']),
   };
 
   return (
@@ -33,22 +37,22 @@ const DriverDetailPage = () => {
           <div className={style.section}>
             <div className={style.border}></div>
             <h2 className={style.sectionTitle}>상세설명</h2>
-            <p className={style.description}>{transformedDriver.description}</p>
+            <p className={style.description}>{driver.description}</p>
             <div className={style.border}></div>
             <h2 className={style.sectionTitle}>제공 서비스</h2>
             <div className={style.chips}>
-              {transformedDriver.serviceType.map((type, index) => (
+              {driver.serviceType.map((type, index) => (
                 <span key={index} className={style.serviceChip}>
-                  {type}
+                  {translateServiceType(type)}
                 </span>
               ))}
             </div>
             <div className={style.border}></div>
             <h2 className={style.sectionTitle}>서비스 가능 지역</h2>
             <div className={style.chips}>
-              {transformedDriver.serviceRegion.map((region, index) => (
+              {driver.serviceRegion.map((region, index) => (
                 <span key={index} className={style.regionChip}>
-                  {region}
+                  {translateServiceRegion(region)}
                 </span>
               ))}
             </div>
@@ -56,7 +60,7 @@ const DriverDetailPage = () => {
           </div>
         </div>
         <div className={style.rightFilters}>
-          <h2>{transformedDriver.nickname} 기사님에게 지정 견적을 요청해보세요!</h2>
+          <h2>{driver.nickname} 기사님에게 지정 견적을 요청해보세요!</h2>
         </div>
       </div>
     </div>
@@ -64,4 +68,3 @@ const DriverDetailPage = () => {
 };
 
 export default DriverDetailPage;
-

--- a/src/page/root/searchDriver/index.tsx
+++ b/src/page/root/searchDriver/index.tsx
@@ -9,7 +9,8 @@ import DriverCard from '../../../components/card/DriverCard';
 import style from './index.module.css';
 import { translations, REGION_ITEMS, SERVICE_ITEMS } from '../searchDriver/utils/Constants';
 import { MOCK_DATA } from '../searchDriver/mockData';
-import { translateServiceRegion, translateServiceType } from './EnumMapper';
+import { ChipProps } from '../../../components/chip/Chip';
+
 
 const FILTER_TYPES = {
   REGION: 'region',
@@ -33,7 +34,7 @@ const SearchDriverForGuest = () => {
   const [filteredData, setFilteredData] = useState(MOCK_DATA); // 필터링된 데이터 상태
   const [isMediumScreen, setIsMediumScreen] = useState<boolean>(window.innerWidth <= 1199);
   const [isSmallScreen, setIsSmallScreen] = useState<boolean>(window.innerWidth <= 744);
-  const navigate = useNavigate(); // 라우터 네비게이션 훅
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handleResize = () => {
@@ -140,14 +141,13 @@ const SearchDriverForGuest = () => {
     >
       {filteredData.map((user) => (
         <DriverCard
-          key={user.id}
-          user={{
-            ...user,
-            serviceRegion: user.serviceRegion.map(translateServiceRegion),
-            serviceType: user.serviceType.map(translateServiceType),
-          }}
-          onClick={() => handleCardClick(user.id)}
-        />
+        key={user.id}
+        user={{
+          ...user,
+          serviceType: user.serviceType.map((type) => type as ChipProps["type"]),
+        }}
+        onClick={() => handleCardClick(user.id)}
+      />
       ))}
     </div>
   );
@@ -156,15 +156,13 @@ const SearchDriverForGuest = () => {
     <div className={style.favoriteDriversContainer}>
       {MOCK_DATA.map((user) => (
         <DriverCard
-          key={user.id}
-          user={{
-            ...user,
-            serviceRegion: user.serviceRegion.map(translateServiceRegion),
-            serviceType: user.serviceType.map(translateServiceType),
-          }}
-          type="dibs"
-          onClick={() => handleCardClick(user.id)}
-        />
+        key={user.id}
+        user={{
+          ...user,
+          serviceType: user.serviceType.map((type) => type as ChipProps["type"]),
+        }}
+        onClick={() => handleCardClick(user.id)}
+      />
       ))}
     </div>
   );

--- a/src/page/user/favoriteMover/mockData.ts
+++ b/src/page/user/favoriteMover/mockData.ts
@@ -1,4 +1,4 @@
-type ChipType = 'SMALL' | 'HOME' | 'COMPANY' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
+type ChipType = 'SMALL' | 'HOUSE' | 'OFFICE' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
 
 // 데이터 연결을 위한 임시 mockData (지울 예정)
 export interface Mover {
@@ -27,7 +27,7 @@ export const mockData: ApiResponse = {
   list: [
     {
       id: 1,
-      serviceType: ['SMALL', 'COMPANY'],
+      serviceType: ['SMALL', 'OFFICE'],
       isAssigned: true,
       nickname: '김기사',
       profileImage: 'https://via.placeholder.com/150',
@@ -42,7 +42,7 @@ export const mockData: ApiResponse = {
     },
     {
       id: 2,
-      serviceType: ['HOME'],
+      serviceType: ['HOUSE'],
       isAssigned: false,
       nickname: '이기사',
       profileImage: 'https://via.placeholder.com/150',
@@ -57,7 +57,7 @@ export const mockData: ApiResponse = {
     },
     {
       id: 3,
-      serviceType: ['COMPANY', 'SMALL'],
+      serviceType: ['OFFICE', 'SMALL'],
       isAssigned: true,
       nickname: '박기사',
       profileImage: 'https://via.placeholder.com/150',
@@ -87,7 +87,7 @@ export const mockData: ApiResponse = {
     },
     {
       id: 5,
-      serviceType: ['HOME', 'COMPANY'],
+      serviceType: ['HOUSE', 'OFFICE'],
       isAssigned: true,
       nickname: '송기사',
       profileImage: 'https://via.placeholder.com/150',
@@ -117,7 +117,7 @@ export const mockData: ApiResponse = {
     },
     {
       id: 7,
-      serviceType: ['COMPANY'],
+      serviceType: ['OFFICE'],
       isAssigned: true,
       nickname: '박기사',
       profileImage: 'https://via.placeholder.com/150',
@@ -132,7 +132,7 @@ export const mockData: ApiResponse = {
     },
     {
       id: 8,
-      serviceType: ['HOME'],
+      serviceType: ['HOUSE'],
       isAssigned: false,
       nickname: '정기사',
       profileImage: 'https://via.placeholder.com/150',

--- a/src/page/user/receivedCostDetail/components/ReceivedCostInfo.tsx
+++ b/src/page/user/receivedCostDetail/components/ReceivedCostInfo.tsx
@@ -6,9 +6,9 @@ export default function ReceivedCostInfo({ info }: infoProps) {
     switch (type) {
       case 'SMALL':
         return '소형이사';
-      case 'HOME':
+      case 'HOUSE':
         return '가정이사';
-      case 'COMPANY':
+      case 'OFFICE':
         return '사무실 이사';
       default:
         return '';

--- a/src/page/user/receivedCostDetail/mockData.ts
+++ b/src/page/user/receivedCostDetail/mockData.ts
@@ -1,4 +1,4 @@
-type ChipType = 'SMALL' | 'HOME' | 'COMPANY' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
+type ChipType = 'SMALL' | 'HOUSE' | 'OFFICE' | 'ASSIGN' | 'CONFIRM' | 'WAITING';
 
 export interface infoProps {
   info: {
@@ -70,7 +70,7 @@ export const mockData: mockDataProps = {
       id: 1,
       moverId: 2,
       isConfirmed: true,
-      serviceType: ['SMALL', 'COMPANY'],
+      serviceType: ['SMALL', 'OFFICE'],
       summary: '맡겨만 주세요!',
       isAssigned: false,
       profileImage: 'https://via.placeholder.com/150',
@@ -89,7 +89,7 @@ export const mockData: mockDataProps = {
       id: 1,
       moverId: 1,
       isConfirmed: false,
-      serviceType: ['HOME'],
+      serviceType: ['HOUSE'],
       summary: '20년 경력입니다!',
       isAssigned: true,
       profileImage: 'https://via.placeholder.com/150',


### PR DESCRIPTION
#### 추가사항
- [x] `COMPANY` => `OFFICE`
- [x] `HOME`=> `HOUSE`
- [x] `ChipProps`인터페이스를 외부에서 사용할 수 있도록 `export`추가

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ]

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷

![image](이미지url)

#### 코멘트
- 백엔드 필드명에 맞춰 목 데이터 및 컴포넌트 전부 수정 완료해두었습니다.