### PR TITLE
[박명준] Tab 공통 컴포넌트 기능 추가

### DIFF
--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -1,40 +1,50 @@
 import classNames from 'classnames';
 import style from './Tab.module.css';
 
-interface TabProps {
+// Define type for tab options based on hasThirdTab
+type TabOptions<T extends boolean> = T extends true
+  ? 'first' | 'second' | 'third'
+  : 'first' | 'second';
+
+// Generic interface for TabProps
+interface TabProps<T extends boolean = false> {
   selectable?: boolean;
   firstText: string;
   secondText?: string;
-  selectedTab?: 'first' | 'second';
-  onTabChange?: (selectedTab: 'first' | 'second') => void;
+  thirdText?: string;
+  selectedTab?: TabOptions<T>;
+  hasThirdTab?: T;
+  onTabChange?: (selectedTab: TabOptions<T>) => void;
   tabChangeType?: 'state' | 'route';
   firstTabRoute?: () => void;
   secondTabRoute?: () => void;
 }
 
-export default function Tab({
+export default function Tab<T extends boolean = false>({
   selectable = false,
   firstText,
   secondText,
+  thirdText,
   selectedTab,
+  hasThirdTab = false as T,
   onTabChange,
   tabChangeType = 'state',
   firstTabRoute,
   secondTabRoute,
-}: TabProps) {
-  const handleTabClick = (tab: 'first' | 'second') => {
+}: TabProps<T>) {
+  const handleTabClick = (tab: TabOptions<T>) => {
     if (tabChangeType === 'state') {
       onTabChange?.(tab);
     } else if (tabChangeType === 'route') {
       if (tab === 'first') {
         firstTabRoute?.();
-      } else {
+      } else if (tab === 'second') {
         secondTabRoute?.();
       }
     }
   };
 
-  const renderTab = (tab: 'first' | 'second', text: string | undefined) => (
+  const renderTab = (tab: TabOptions<T>, text: string | undefined) => (
     <div
       className={classNames(style.selectedContent, {
         [style.active]: selectedTab === tab,
@@ -51,6 +61,7 @@ export default function Tab({
         <div className={style.select}>
           {renderTab('first', firstText)}
           {renderTab('second', secondText)}
+          {hasThirdTab && renderTab('third' as TabOptions<T>, thirdText)}
         </div>
       ) : (
         <div className={style.nonSelect}>


### PR DESCRIPTION
#### 추가사항

- 탭 3개 다루기


#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ] 견적 정보 컴포넌트 마저 진행
- [ ] 대기 중인 견적 페이지 진행

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷

![](https://velog.velcdn.com/images/pmj9498/post/3c9721ae-ab80-40ef-841a-fdd060a52f32/image.png)

#### 코멘트
사용예시
```tsx
const [currentTab, setCurrentTab] = useState<'first' | 'second' | 'third'>(
    'first',
  );
// ...
<>
      <Tab
        selectable={true}
        firstText='작성 가능한 리뷰'
        secondText='내가 작성한 리뷰'
        thirdText='세 번째 탭' // 세 번째 탭 타이틀
        hasThirdTab={true} // 세 번째 탭 유무
        selectedTab={currentTab}
        onTabChange={(tab) => setCurrentTab(tab)}
      />
  // ...
  <div className={style.container}>
          {currentTab === 'first' ? (
            <WritableReviews
              setIsModalOpen={setIsModalOpen}
              setSelectedMover={setSelectedMover}
            />
          ) : currentTab === 'second' ? (
            <MyReview />
          ) : <div>세 번째 탭 컴포넌트</div>}
        </div>
  ```
