### PR TITLE
[이율리] 견적 관리 페이지 기본 레이아웃 구현

### DIFF
--- a/src/components/card/DriverProfile.module.css
+++ b/src/components/card/DriverProfile.module.css
@@ -69,7 +69,7 @@
 }
 
 .avatarLarge {
-  width: 100px;
+  width: 120px;
   height: 100px;
 }
 

--- a/src/components/card/UserProfile.module.css
+++ b/src/components/card/UserProfile.module.css
@@ -170,6 +170,11 @@
   }
   
   .profileImage {
+    width: 46px;
+    height: 46px;
+  }
+  
+  .avatar {
     width: 60px;
     height: 60px;
   }

--- a/src/page/driver/costCall/index.module.css
+++ b/src/page/driver/costCall/index.module.css
@@ -1,7 +1,7 @@
 .container {
   width: 100%;
   height: 100%;
-  max-width: 1400px;
+  max-width: 1920px;
   padding: 0 120px;
   /* 반응형 추후 추가 시 min-width: 332px */
 }
@@ -19,6 +19,7 @@
   padding: 24px;
   display: flex;
   gap: 100px;
+  justify-content: space-between;
 }
 
 .filterBox {

--- a/src/page/driver/costCall/index.tsx
+++ b/src/page/driver/costCall/index.tsx
@@ -27,13 +27,13 @@ export default function DriverCostCallPage() {
   const isPc = useMedia().pc;
   const itemsPerPage = 3;
 
-  const handlePageChange = (page: number) => {
-    setCurrentPage(page);
-  };
-
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const currentUsers = mockData.users.slice(startIndex, endIndex);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
 
   const page = {
     currentPage: currentPage,

--- a/src/page/driver/costHandler/index.module.css
+++ b/src/page/driver/costHandler/index.module.css
@@ -21,7 +21,7 @@
 }
 
 .card {
-  max-width: 828px;
+  max-width: calc(50% - 12px);
   flex: 1 1 calc(50% - 24px);
   margin-bottom: 24px;
 }

--- a/src/page/driver/costHandler/index.module.css
+++ b/src/page/driver/costHandler/index.module.css
@@ -1,23 +1,32 @@
 .container {
-  display: flex;
-  flex-wrap: wrap;
   width: 100%;
   height: 100%;
   max-width: 1920px;
-  padding: 0 120px;
+  /* 반응형 추후 추가 시 min-width: 332px */
+}
+
+.mainContainer {
+  margin-top: 40px;
+  padding: 0 120px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cardList {
+  display: flex;
+  flex-wrap: wrap;
   gap: 24px;
+  justify-content: space-between;
 }
 
-.cardWrapper {
-  width: calc(50% - 24px); 
-  box-sizing: border-box;
-  margin-bottom: 20px; 
+.card {
+  max-width: 828px;
+  flex: 1 1 calc(50% - 24px);
+  margin-bottom: 24px;
 }
 
-@media (max-width: 1199px) { 
-  .cardWrapper {
-    width: 100%; 
-    box-sizing: border-box;
-    margin-bottom: 20px; 
-  }
+.pagination {
+  display: flex;
+  justify-content: center;
 }

--- a/src/page/driver/costHandler/index.tsx
+++ b/src/page/driver/costHandler/index.tsx
@@ -1,24 +1,36 @@
 import { useState } from 'react';
+
 import Tab from '../../../components/tab/Tab';
+import UserCard from '../../../components/card/UserCard';
+import Pagination from '../../../components/pagination/Pagination';
 
 import style from './index.module.css';
 
 import { mockData } from './mockData';
-import UserCard from '../../../components/card/UserCard';
-import Pagination from '../../../components/pagination/Pagination';
 
 export default function DriverCostHandlerPage() {
   const [currentPage, setCurrentPage] = useState(1);
-  const [currentTab, setCurrentTab] = useState<'first' | 'second'>('first');
+  const [currentTab, setCurrentTab] = useState<'first' | 'second' | 'third'>(
+    'first',
+  );
+  const [list, setList] = useState(mockData.users);
+
+    const handleTabChange = (tab: 'first' | 'second' | 'third') => {
+      setCurrentTab(tab);
+      if(tab === 'first'){
+        setList(mockData.users)
+      } else if(tab === 'second'){
+        setList(mockData.users.filter((list) => list.isConfirmed))
+      } else {
+        setList(mockData.users.filter((list) => list.isCancelled))
+      }
+      setCurrentPage(1)
+    };
 
   const itemsPerPage = 6;
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
-  const currentUsers = mockData.users.slice(startIndex, endIndex);
-
-  const handleTabChange = (tab: 'first' | 'second') => {
-    setCurrentTab(tab);
-  };
+  const selectedPage = list.slice(startIndex, endIndex);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -27,7 +39,7 @@ export default function DriverCostHandlerPage() {
   const page = {
     currentPage: currentPage,
     itemsPerPage: itemsPerPage,
-    data: 10,
+    data: list.length,
     onPageChange: handlePageChange,
   };
 
@@ -35,23 +47,24 @@ export default function DriverCostHandlerPage() {
     <div className={style.container}>
       <Tab
         selectable={true}
-        firstText='보낸 견적 전체 조회'
+        firstText='견적 전체 조회'
         secondText='확정 견적 조회'
-        // thirdText='반려 요청ㆍ취소 조회'
+        thirdText='반려ㆍ취소 요청'
+        hasThirdTab={true}
         selectedTab={currentTab}
         onTabChange={handleTabChange}
       />
       <div className={style.mainContainer}>
         {currentTab && (
           <div className={style.cardList}>
-            {currentUsers.map((user, index) => (
+            {selectedPage.map((user, index) => (
               <div key={index} className={style.card}>
                 <UserCard user={user} type='confirmedCost' />
               </div>
             ))}
           </div>
         )}
-        {currentUsers.length > 0 && (
+        {selectedPage.length > 0 && (
           <div className={style.pagination}>
             <Pagination {...page} />
           </div>

--- a/src/page/driver/costHandler/index.tsx
+++ b/src/page/driver/costHandler/index.tsx
@@ -1,41 +1,62 @@
-import DriverCard from '../../../components/card/DriverCard';
-
-// import { DriverProfileType } from '../../../components/card/type';
+import { useState } from 'react';
+import Tab from '../../../components/tab/Tab';
 
 import style from './index.module.css';
 
 import { mockData } from './mockData';
+import UserCard from '../../../components/card/UserCard';
+import Pagination from '../../../components/pagination/Pagination';
 
 export default function DriverCostHandlerPage() {
-  // const getType = (isConfirmed: boolean, isCancelled: boolean):DriverProfileType => {
-  //   if (isConfirmed && !isCancelled) return 'confirm'; // 확정된 경우
-  //   if (!isConfirmed && !isCancelled) return 'notConfirm'; // 확정X된된 경우
-  //   if (!isConfirmed && isCancelled) return 'cancel'; // 취소된 경우
-  //   return 'waiting'; // 기본 상태
-  // };
+  const [currentPage, setCurrentPage] = useState(1);
+  const [currentTab, setCurrentTab] = useState<'first' | 'second'>('first');
+
+  const itemsPerPage = 6;
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const currentUsers = mockData.users.slice(startIndex, endIndex);
+
+  const handleTabChange = (tab: 'first' | 'second') => {
+    setCurrentTab(tab);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const page = {
+    currentPage: currentPage,
+    itemsPerPage: itemsPerPage,
+    data: 10,
+    onPageChange: handlePageChange,
+  };
 
   return (
     <div className={style.container}>
-      {mockData.users.map((user) => (
-        <div key={user.id} className={style.cardWrapper}>
-          {/* <DriverCard
-            user={user}
-            type={getType(Boolean(user.isConfirmed), Boolean(user.isCancelled))}
-          /> */}
-          기사님 찾기
-          <DriverCard user={user} />
-          견적내역
-          <DriverCard user={user} type='cost' />
-          대기중인 내역
-          <DriverCard user={user} type='waiting' />
-          찜한 기사님
-          <DriverCard user={user} type='dibs' />
-          작성 가능한 리뷰
-          <DriverCard user={user} type='review' />
-        </div>
-      ))}
-      profile
-      <DriverCard user={mockData.users[0]} type='profile' />
+      <Tab
+        selectable={true}
+        firstText='보낸 견적 전체 조회'
+        secondText='확정 견적 조회'
+        // thirdText='반려 요청ㆍ취소 조회'
+        selectedTab={currentTab}
+        onTabChange={handleTabChange}
+      />
+      <div className={style.mainContainer}>
+        {currentTab && (
+          <div className={style.cardList}>
+            {currentUsers.map((user, index) => (
+              <div key={index} className={style.card}>
+                <UserCard user={user} type='confirmedCost' />
+              </div>
+            ))}
+          </div>
+        )}
+        {currentUsers.length > 0 && (
+          <div className={style.pagination}>
+            <Pagination {...page} />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/page/driver/costHandler/mockData.ts
+++ b/src/page/driver/costHandler/mockData.ts
@@ -1,118 +1,141 @@
 import { ChipType } from "../../../components/card/type";
-import avatar from '../../../assets/images/img_avatar_pink_medium.svg'
 
-export interface DriverData {
+export interface UserData {
   users: {
-    id: number; // 기사 아이디
-    serviceType?: ChipType[]; // 서비스 유형
+    id: number; // 고객 아이디
+    movingType?: ChipType[]; // 서비스 유형
     isConfirmed?: boolean; // 확정된 요청인지 확인(true)
     isCancelled?: boolean; // 취소 여부 (false)
     isAssigned?: boolean; // 지정경적 여부
-    profileImage: string; // 프로필 이미지
-    nickname: string; // 기사 닉네임
-    career?: number; // 경력
-    reviewStats?: {
-      averageScore?: number; // 평점
-      totalReviews?: number; // 리뷰 갯수
-    };
-    favoriteCount?: number; // 찜 갯수
-    confirmationCount?: number; // 확정 건 수
+    customer: string; // 고객 이름
     movingDate?: string; // 이사 날짜
     departure?: string; // 출발지
     arrival?: string; // 도착지
-    isLiked?: boolean; // 찜 여부
     price?: number; //견적가
   }[];
 }
 
-export const mockData: DriverData = {
+export const mockData: UserData = {
   users: [
-    // 확정된 견적 요청일 때
     {
       id: 1,
-      serviceType: ['SMALL', 'OFFICE'],
+      movingType: ['SMALL', 'OFFICE'],
       isConfirmed: true,
       isCancelled: false,
       isAssigned: true,
-      profileImage: avatar,
-      nickname: 'driver1',
-      career: 7,
-      reviewStats: {
-        averageScore: 4.2,
-        totalReviews: 20,
-      },
-      favoriteCount: 10,
-      confirmationCount: 30,
+      customer: 'user1',
       movingDate: '2024.12.10',
       departure: '서울특별시 강남구',
       arrival: '서울특별시 마포구',
-      isLiked: true,
       price: 500000,
     },
-    // 확정되지 않은 견적 요청일 때
     {
       id: 2,
-      serviceType: ['HOUSE'],
+      movingType: ['HOUSE'],
       isConfirmed: false,
       isCancelled: false,
       isAssigned: true,
-      profileImage: avatar,
-      nickname: 'driver2',
-      career: 20,
-      reviewStats: {
-        averageScore: 4.5,
-        totalReviews: 100,
-      },
-      favoriteCount: 200,
-      confirmationCount: 500,
+      customer: 'user2',
       movingDate: '2024.07.15',
       departure: '서울특별시 은평구',
       arrival: '서울특별시 종로구',
-      isLiked: false,
       price: 500000,
     },
-    // // 확정된 견적 요청일 때
-    // {
-    //   id: 3,
-    //   serviceType: ['OFFICE'],
-    //   isConfirmed: true,
-    //   isCancelled: false,
-    //   isAssigned: false,
-    //   profileImage: 'image3',
-    //   nickname: 'driver3',
-    //   career: 10,
-    //   reviewStats: {
-    //     averageScore: 3.8,
-    //     totalReviews: 40,
-    //   },
-    //   favoriteCount: 15,
-    //   confirmationCount: 25,
-    //   movingDate: '2024.08.01',
-    //   departure: '경기도 성남시',
-    //   arrival: '경기도 부천시',
-    //   isLiked: true,
-    //   price: 650000,
-    // },
-    // // 취소된 견적 요청일 때
-    // {
-    //   id: 4,
-    //   serviceType: ['SMALL'],
-    //   isConfirmed: false,
-    //   isCancelled: true,
-    //   profileImage: 'image4',
-    //   nickname: 'driver4',
-    //   career: 12,
-    //   reviewStats: {
-    //     averageScore: 4.7,
-    //     totalReviews: 50,
-    //   },
-    //   favoriteCount: 35,
-    //   confirmationCount: 45,
-    //   movingDate: '2024.09.01',
-    //   departure: '인천광역시 연수구',
-    //   arrival: '인천광역시 계양구',
-    //   isLiked: false,
-    //   price: 720000,
-    // },
+    {
+      id: 3,
+      movingType: ['OFFICE'],
+      isConfirmed: true,
+      isCancelled: false,
+      isAssigned: false,
+      customer: 'user3',
+      movingDate: '2024.08.01',
+      departure: '경기도 성남시',
+      arrival: '경기도 부천시',
+      price: 650000,
+    },
+    {
+      id: 4,
+      movingType: ['SMALL'],
+      isConfirmed: false,
+      isCancelled: true,
+      isAssigned: false,
+      customer: 'user4',
+      movingDate: '2024.09.01',
+      departure: '인천광역시 연수구',
+      arrival: '인천광역시 계양구',
+      price: 720000,
+    },
+    {
+      id: 5,
+      movingType: ['HOUSE'],
+      isConfirmed: true,
+      isCancelled: false,
+      isAssigned: true,
+      customer: 'user5',
+      movingDate: '2024.10.20',
+      departure: '경기도 안양시',
+      arrival: '서울특별시 서대문구',
+      price: 550000,
+    },
+    {
+      id: 6,
+      movingType: ['OFFICE'],
+      isConfirmed: false,
+      isCancelled: false,
+      isAssigned: true,
+      customer: 'user6',
+      movingDate: '2024.11.01',
+      departure: '서울특별시 동대문구',
+      arrival: '서울특별시 강북구',
+      price: 480000,
+    },
+    {
+      id: 7,
+      movingType: ['SMALL'],
+      isConfirmed: true,
+      isCancelled: false,
+      isAssigned: false,
+      customer: 'user7',
+      movingDate: '2024.12.05',
+      departure: '서울특별시 성동구',
+      arrival: '경기도 광주시',
+      price: 610000,
+    },
+    {
+      id: 8,
+      movingType: ['HOUSE', 'OFFICE'],
+      isConfirmed: false,
+      isCancelled: true,
+      isAssigned: false,
+      customer: 'user8',
+      movingDate: '2024.06.25',
+      departure: '인천광역시 남동구',
+      arrival: '경기도 수원시',
+      price: 700000,
+    },
+    {
+      id: 9,
+      movingType: ['HOUSE'],
+      isConfirmed: true,
+      isCancelled: false,
+      isAssigned: true,
+      customer: 'user9',
+      movingDate: '2024.08.15',
+      departure: '경기도 성남시',
+      arrival: '서울특별시 관악구',
+      price: 640000,
+    },
+    {
+      id: 10,
+      movingType: ['OFFICE'],
+      isConfirmed: false,
+      isCancelled: false,
+      isAssigned: true,
+      customer: 'user10',
+      movingDate: '2024.09.10',
+      departure: '경기도 용인시',
+      arrival: '서울특별시 중랑구',
+      price: 580000,
+    },
   ],
 };

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -132,11 +132,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'costHandler',
-        element: (
-          <span>
-            <DriverCostHandlerPage />
-          </span>
-        ),
+        element: <DriverCostHandlerPage />,
       },
       {
         path: 'myPage',


### PR DESCRIPTION
#### 추가사항

#67 
- [x] 견적관리 페이지 기본 레이아웃 구현
- [x] 탭 별 화면 구성
- [x] 페이지 별 컴포넌트 연결

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ] 반려, 취소, 지난 이사일 카드 레이아웃 추가

#### 테스트 완료 여부

- [ ] 테스트 완료

#### 스크린샷

![image](https://github.com/user-attachments/assets/a5c4a3ec-2c2c-4872-89ea-f3acc01307c8)

#### 코멘트

