### PR TITLE
[이율리] 페이지, 카드 컴포넌트 최적화

### DIFF
--- a/src/components/card/DriverCard.module.css
+++ b/src/components/card/DriverCard.module.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--gray-50);
+  cursor: pointer;
 }
 
 .cardPType {
@@ -19,6 +20,15 @@
 
 .cardPRType {
   gap: 32px;
+  cursor: default;
+}
+
+.cardWType {
+  cursor: default;
+}
+
+.cardCType {
+  cursor: default;
 }
 
 .cardPSmall {

--- a/src/components/card/DriverCard.module.css
+++ b/src/components/card/DriverCard.module.css
@@ -12,6 +12,7 @@
 
 .cardPType {
   background-color: var(--background-200);
+  cursor: default;
 }
 
 .cardCDType {

--- a/src/components/card/DriverCard.module.css
+++ b/src/components/card/DriverCard.module.css
@@ -81,6 +81,10 @@
   min-height: 32px;
 }
 
+.chipBoxSmall {
+  min-height: 24px;
+}
+
 .chip {
   display: flex;
   gap: 12px;

--- a/src/components/card/DriverCard.tsx
+++ b/src/components/card/DriverCard.tsx
@@ -85,17 +85,21 @@ export default function DriverCard({
       ) : (
         // 칩
         <div className={style.chipBox}>
-          {chips.map((row, rowIndex) => (
-            <div key={rowIndex} className={style.chip}>
-              {row.map((chip, chipIndex) => (
-                <Chip
-                  key={chipIndex}
-                  type={chip}
-                  size={type === 'dibs' ? 'favorite' : 'noFavorite'}
-                />
-              ))}
-            </div>
-          ))}
+          {chips
+            .map(
+              (row) => row.sort((a, b) => (a < b ? -1 : 1))
+            )
+            .map((row, rowIndex) => (
+              <div key={rowIndex} className={style.chip}>
+                {row.map((chip, chipIndex) => (
+                  <Chip
+                    key={chipIndex}
+                    type={chip}
+                    size={type === 'dibs' ? 'favorite' : 'noFavorite'}
+                  />
+                ))}
+              </div>
+            ))}
         </div>
       )}
       {(type === 'cost' || type === undefined || type === 'dibs') && (

--- a/src/components/card/DriverCard.tsx
+++ b/src/components/card/DriverCard.tsx
@@ -6,7 +6,7 @@ import Button from '../btn/Button';
 import Chip from '../chip/Chip';
 
 import { useMedia } from '../../lib/function/useMediaQuery';
-import { formatCurrency, getChips } from '../../lib/function/utils';
+import { checkImg, formatCurrency, getChips } from '../../lib/function/utils';
 import { ChipType, DriverProfileProps } from '../../types/cardTypes';
 
 import style from './DriverCard.module.css';
@@ -60,7 +60,7 @@ export default function DriverCard({
           {!isPc && (
             <div className={style.profileImage}>
               <img
-                src={list.profileImg}
+                src={checkImg(list.profileImg)}
                 alt={`${list.moverName}'s profile`}
                 className={style.avatar}
               />

--- a/src/components/card/DriverCard.tsx
+++ b/src/components/card/DriverCard.tsx
@@ -48,6 +48,8 @@ export default function DriverCard({
         [style.cardPType]: type === 'profile',
         [style.cardCDType]: type === 'cost' || type === 'dibs',
         [style.cardPRType]: type === 'review',
+        [style.cardWType]: type === 'waiting',
+        [style.cardCType]: type === 'confirm' || type === 'notConfirm' || type === 'cancel',
         [style.cardPSmall]: styles === 'small',
       })}
       onClick={onClick} // 최상단 div에 onClick 이벤트 추가

--- a/src/components/card/DriverCard.tsx
+++ b/src/components/card/DriverCard.tsx
@@ -49,7 +49,8 @@ export default function DriverCard({
         [style.cardCDType]: type === 'cost' || type === 'dibs',
         [style.cardPRType]: type === 'review',
         [style.cardWType]: type === 'waiting',
-        [style.cardCType]: type === 'confirm' || type === 'notConfirm' || type === 'cancel',
+        [style.cardCType]:
+          type === 'confirm' || type === 'notConfirm' || type === 'cancel',
         [style.cardPSmall]: styles === 'small',
       })}
       onClick={onClick} // 최상단 div에 onClick 이벤트 추가
@@ -86,11 +87,13 @@ export default function DriverCard({
         </div>
       ) : (
         // 칩
-        <div className={style.chipBox}>
+        <div
+          className={classNames(style.chipBox, {
+            [style.chipBoxSmall]: styles === 'small',
+          })}
+        >
           {chips
-            .map(
-              (row) => row.sort((a, b) => (a < b ? -1 : 1))
-            )
+            .map((row) => row.sort((a, b) => (a < b ? -1 : 1)))
             .map((row, rowIndex) => (
               <div key={rowIndex} className={style.chip}>
                 {row.map((chip, chipIndex) => (

--- a/src/components/card/DriverProfile.module.css
+++ b/src/components/card/DriverProfile.module.css
@@ -6,7 +6,6 @@
   padding: 16px 18px;
   border: 1px solid var(--line-100);
   border-radius: 6px;
-  cursor: pointer;
 }
 
 .profilePType {
@@ -16,6 +15,7 @@
 
 .profileRType {
   border: none;
+  cursor: pointer;
 }
 
 .region {
@@ -25,6 +25,7 @@
 
 .profileWType {
   height: 92px;
+  cursor: pointer;
 }
 
 .profileSmall {

--- a/src/components/card/DriverProfile.tsx
+++ b/src/components/card/DriverProfile.tsx
@@ -25,6 +25,16 @@ export default function DriverProfile({
   const { direction_driverDetail } = useDirection();
   const id = Number(user.moverId);
 
+  const handleProfileClick = () => {
+    if (
+      type === 'waiting' ||
+      type === 'confirm' ||
+      type === 'review' ||
+      type === 'dibs'
+    )
+      return direction_driverDetail(id);
+  };
+
   return (
     <div
       className={classNames(style.profile, {
@@ -33,7 +43,7 @@ export default function DriverProfile({
         [style.profileWType]: type === 'waiting' || type === 'confirm',
         [style.profileSmall]: styles === 'small',
       })}
-      onClick={()=>direction_driverDetail(id)}
+      onClick={() => handleProfileClick()}
     >
       <div
         className={classNames(style.profileImage, {

--- a/src/components/card/DriverProfile.tsx
+++ b/src/components/card/DriverProfile.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 
 import { useMedia } from '../../lib/function/useMediaQuery';
 import {
+  checkImg,
   formatCurrency,
   translateServiceRegion,
   translateServiceType,
@@ -55,11 +56,13 @@ export default function DriverProfile({
         })}
       >
         <img
-          src={user.profileImg}
+          src={checkImg(user.profileImg)}
           alt={`${user.moverName}'s profile`}
           className={classNames(style.avatar, {
             [style.avatarLarge]:
-              (type === 'profile' || type === 'dibs' || type === 'review') &&
+              (type === 'profile' ||
+                (type === 'dibs' && styles !== 'small') ||
+                type === 'review') &&
               isPc,
           })}
         />

--- a/src/components/card/UserCard.module.css
+++ b/src/components/card/UserCard.module.css
@@ -27,7 +27,7 @@
   gap: 12px;
 }
 
-.chip { 
+.chip {
   display: flex;
   gap: 12px;
 }

--- a/src/components/card/UserCard.tsx
+++ b/src/components/card/UserCard.tsx
@@ -47,13 +47,15 @@ export default function UserCard({
       <div className={style.top}>
         {/* 칩 */}
         <div className={style.chipBox}>
-          {chips.map((row, rowIndex) => (
-            <div key={rowIndex} className={style.chip}>
-              {row.map((chip, chipIndex) => (
-                <Chip key={chipIndex} type={chip} />
-              ))}
-            </div>
-          ))}
+          {chips
+            .map((row) => row.sort((a, b) => (a < b ? -1 : 1)))
+            .map((row, rowIndex) => (
+              <div key={rowIndex} className={style.chip}>
+                {row.map((chip, chipIndex) => (
+                  <Chip key={chipIndex} type={chip} />
+                ))}
+              </div>
+            ))}
         </div>
         {type !== 'review' ? (
           <div className={style.createAt}>

--- a/src/components/card/UserCard.tsx
+++ b/src/components/card/UserCard.tsx
@@ -59,11 +59,15 @@ export default function UserCard({
         </div>
         {type !== 'review' ? (
           <div className={style.createAt}>
-            {list.createAt && getNotificationDate(list.createAt, 'noSec')}
+            {list.createAt ||
+              (list.updatedAt &&
+                getNotificationDate(list.createAt || list.updatedAt, 'noSec'))}
           </div>
         ) : (
           <div className={style.createAtRType}>
-            {list.createAt && getNotificationDate(list.createAt, 'noSec')}
+            {list.createAt ||
+              (list.updatedAt &&
+                getNotificationDate(list.createAt || list.updatedAt, 'noSec'))}
           </div>
         )}
       </div>

--- a/src/components/card/UserProfile.module.css
+++ b/src/components/card/UserProfile.module.css
@@ -71,6 +71,7 @@
   padding: 16px 18px;
   border: 1px solid var(--line-100);
   min-width: 299px;
+  cursor: pointer;
 }
 
 .profileImage {

--- a/src/components/card/UserProfile.tsx
+++ b/src/components/card/UserProfile.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { formatCurrency } from '../../lib/function/utils';
 import { useMedia } from '../../lib/function/useMediaQuery';
 import { UserProfileProps } from '../../types/cardTypes';
+import useDirection from '../../lib/function/direction';
 
 import style from './UserProfile.module.css';
 
@@ -51,6 +52,9 @@ export function getStars(rating: number) {
 export default function UserProfile({ type, list: user }: UserProfileProps) {
   const isPc = useMedia().pc;
   const isMobile = useMedia().mobile;
+
+  const { direction_driverDetail } = useDirection();
+
   return (
     <>
       {type !== 'review' ? (
@@ -95,7 +99,7 @@ export default function UserProfile({ type, list: user }: UserProfileProps) {
           </div>
         </div>
       ) : (
-        <div className={style.reviewProfile}>
+        <div className={style.reviewProfile} onClick={() => direction_driverDetail(Number(user.moverId))}>
           <div className={style.profileImage}>
             <img
               src={user.profileImg}

--- a/src/components/card/UserProfile.tsx
+++ b/src/components/card/UserProfile.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 
-import { formatCurrency } from '../../lib/function/utils';
+import { checkImg, formatCurrency } from '../../lib/function/utils';
 import { useMedia } from '../../lib/function/useMediaQuery';
 import { UserProfileProps } from '../../types/cardTypes';
 import useDirection from '../../lib/function/direction';
@@ -102,7 +102,7 @@ export default function UserProfile({ type, list: user }: UserProfileProps) {
         <div className={style.reviewProfile} onClick={() => direction_driverDetail(Number(user.moverId))}>
           <div className={style.profileImage}>
             <img
-              src={user.profileImg}
+              src={checkImg(user.profileImg)}
               alt={`${user.moverName}'s profile`}
               className={style.avatar}
             />

--- a/src/lib/function/utils.ts
+++ b/src/lib/function/utils.ts
@@ -1,4 +1,23 @@
 import { ChipType } from '../../types/cardTypes';
+import avatarBlue from '../../assets/images/img_avatar_blue_medium.svg';
+import avatarGreen from '../../assets/images/img_avatar_green_medium.svg';
+import avatarPink from '../../assets/images/img_avatar_pink_medium.svg';
+import avatarPurple from '../../assets/images/img_avatar_purple_medium.svg';
+import avatarYellow from '../../assets/images/img_avatar_yellow_medium.svg';
+
+export const checkImg = (img: any) => {
+  const defaultImg: Record<number, string> = {
+    1: avatarBlue,
+    2: avatarGreen,
+    3: avatarPink,
+    4: avatarPurple,
+    5: avatarYellow,
+  };
+  const randomImgKey = Math.floor(Math.random() * 5) + 1;
+
+  if (img) return img;
+  else return defaultImg[randomImgKey];
+};
 
 // 시간 변환
 // type => yyyy. mm. dd / ss초 전 표시 x

--- a/src/page/driver/costCall/components/Dropdown.tsx
+++ b/src/page/driver/costCall/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import vectorDownSmall from '../../../../assets/icons/ic_vector_down_small.svg';
 
@@ -10,6 +10,7 @@ interface DropdownProps {
 
 export default function Dropdown({ setSortItem: setSortItem }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [selectedOption, setSelectedOption] = useState('이사 빠른순');
 
   const selectOption = (option: string) => {
@@ -22,13 +23,26 @@ export default function Dropdown({ setSortItem: setSortItem }: DropdownProps) {
     setIsOpen(!isOpen);
   };
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
   return (
     <div>
       <button className={style.dropdown} onClick={dropdownHandler}>
         {selectedOption} <img src={vectorDownSmall} alt='vectorDownSmall' />{' '}
       </button>
       {isOpen && (
-        <div className={style.menu}>
+        <div ref={dropdownRef} className={style.menu}>
           <div
             onClick={() => selectOption('이사 빠른순')}
             className={style.text}

--- a/src/page/driver/costCall/index.tsx
+++ b/src/page/driver/costCall/index.tsx
@@ -7,6 +7,7 @@ import Pagination from '../../../components/pagination/Pagination';
 import Search from '../../../components/search/Search';
 import NoContents from '../../../components/noContents/NoContents';
 import ModalContainer from '../../../components/modal/ModalContainer';
+import LoadingSpinner from '../../../components/loading/LoadingSpinner';
 
 import { useMedia } from '../../../lib/function/useMediaQuery';
 import { useGetMoverEstimateReq } from '../../../lib/useQueries/estimateReq';
@@ -14,7 +15,6 @@ import { useGetMoverEstimateReq } from '../../../lib/useQueries/estimateReq';
 import style from './index.module.css';
 
 import filter from '../../../assets/icons/ic_filter_medium.svg';
-import LoadingSpinner from '../../../components/loading/LoadingSpinner';
 
 export default function DriverCostCallPage() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -41,7 +41,7 @@ export default function DriverCostCallPage() {
 
   const isPc = useMedia().pc;
 
-  const { data, isLoading } = useGetMoverEstimateReq(params);
+  const { data, isFetching } = useGetMoverEstimateReq(params);
 
   const list = data?.list;
   const totalItems = data?.total || 0;
@@ -182,7 +182,7 @@ export default function DriverCostCallPage() {
               </div>
             </div>
           </div>
-          {isLoading ? (
+          {isFetching ? (
             <div className={style.loadingSpinner}>
               <LoadingSpinner thin={true} />
             </div>

--- a/src/page/driver/costDetail/index.tsx
+++ b/src/page/driver/costDetail/index.tsx
@@ -7,6 +7,7 @@ import SnsShare from '../../../components/snsShare/SnsShare';
 import CostInfo from '../../../components/costInfo/CostInfo';
 import NoContents from '../../../components/noContents/NoContents';
 import Toast from '../../../components/toast/Toast';
+import LoadingSpinner from '../../../components/loading/LoadingSpinner';
 
 import { useMedia } from '../../../lib/function/useMediaQuery';
 import { formatCurrency } from '../../../lib/function/utils';
@@ -16,7 +17,6 @@ import { EstimateConsumer, EstimateMover } from '../../../types/apiTypes';
 import style from './index.module.css';
 
 import logoTextLarge from '../../../assets/images/img_logo_text_large.svg';
-import LoadingSpinner from '../../../components/loading/LoadingSpinner';
 
 // 타입 가드 함수
 function isEstimateMover(

--- a/src/page/driver/costHandler/index.tsx
+++ b/src/page/driver/costHandler/index.tsx
@@ -5,6 +5,7 @@ import UserCard from '../../../components/card/UserCard';
 import Pagination from '../../../components/pagination/Pagination';
 import Button from '../../../components/btn/Button';
 import NoContents from '../../../components/noContents/NoContents';
+import LoadingSpinner from '../../../components/loading/LoadingSpinner';
 
 import useDirection from '../../../lib/function/direction';
 import { useMedia } from '../../../lib/function/useMediaQuery';
@@ -18,7 +19,6 @@ import style from './index.module.css';
 
 import icCheckLarge from '../../../assets/icons/ic_check_large.svg';
 import icCheckMedium from '../../../assets/icons/ic_check_medium.svg';
-import LoadingSpinner from '../../../components/loading/LoadingSpinner';
 
 interface User {
   estimateId: number;

--- a/src/page/user/costDetail/index.tsx
+++ b/src/page/user/costDetail/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import DriverCard from '../../../components/card/DriverCard';
 import CostDetailBottomTab from '../costDetail/components/CostDetailBottomTab';
 import CostInfo from '../../../components/costInfo/CostInfo';
@@ -26,6 +26,8 @@ const CostDetail = () => {
   const [isMobileView, setIsMobileView] = useState(window.innerWidth <= 1199);
   const [isFavorite, setIsFavorite] = useState(false);
   const [isConfirmed, setIsConfirmed] = useState(false);
+
+    const navigate = useNavigate();
 
   useEffect(() => {
     const handleResize = () => setIsMobileView(window.innerWidth <= 1199);
@@ -78,6 +80,11 @@ const CostDetail = () => {
     }
   };
 
+  const handleMoverCardClick = (id: number | undefined) => {
+    if (id === undefined) return; // id가 undefined인 경우 클릭 무시
+    navigate(`/driver/${id}`);
+  };
+
   return (
     <div className={style.outerContainer}>
       <div className={style.noPadding}>
@@ -86,7 +93,10 @@ const CostDetail = () => {
 
       <div className={style.container}>
         <div className={style.leftFilters}>
-          <DriverCard list={estimate} type='cost' showPrice={false} />
+          <DriverCard
+            list={estimate}
+            onClick={() => handleMoverCardClick(estimate.moverId)}
+          />
           <div className={style.section}>
             <div className={style.border}></div>
             <h2 className={style.sectionTitle}>견적가</h2>

--- a/src/types/cardTypes.ts
+++ b/src/types/cardTypes.ts
@@ -33,6 +33,7 @@ export interface BaseProps {
     arrival?: string; // 도착지
     price?: number; // 견적가
     createAt?: string; // 작성일
+    updatedAt?: string; // 작성일
     profileImg?: string; // 기사 프로필 이미지 *
     moverId?: number; // 기사 아이디
     reviewStats?: {

--- a/src/types/cardTypes.ts
+++ b/src/types/cardTypes.ts
@@ -34,6 +34,7 @@ export interface BaseProps {
     price?: number; // 견적가
     createAt?: string; // 작성일
     profileImg?: string; // 기사 프로필 이미지 *
+    moverId?: number; // 기사 아이디
     reviewStats?: {
       averageScore?: number; // 평점
       totalReviews?: number; // 리뷰 갯수
@@ -53,7 +54,6 @@ export interface DriverProfileProps extends BaseProps {
   reviewBtn?: () => void; //리뷰 작성하기 버튼
   costListBtn?: () => void; //견적 목록보기 버튼
   list: BaseProps['list'] & {
-    moverId?: number; // 기사 아이디
     estimateId?: number; // 견적 id
     estimateReqId?: number;
     career?: number; // 경력


### PR DESCRIPTION
#### 추가사항

- [x] 칩 순서 정렬 변경
- [x] 프로필 클릭, 카드 클릭 페이지 이동 수정
- [x] 드롭다운 외부 영역 클릭 시 닫힘 이벤트 추가
- [x] 프로필 기본 랜덤 이미지 적용
- [x] 받은 요청 페이지 - 숫자 유지한 채로 로딩스피너 보이게 수정

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ]

#### 테스트 완료 여부

- [ ] 테스트 완료

#### 스크린샷

![image](이미지url)

#### 코멘트

