### PR TITLE
[김효인] 태블릿, 모바일일 때 toast 겹치는 css 수정

### DIFF
--- a/src/components/toast/Toast.module.css
+++ b/src/components/toast/Toast.module.css
@@ -51,6 +51,7 @@
 
   .toastCopyContainer {
     bottom: 90px;
+    height: 64px;
   }
 
   .icon {

--- a/src/components/toast/Toast.module.css
+++ b/src/components/toast/Toast.module.css
@@ -48,6 +48,11 @@
     height: 48px;
     padding: 10px 24px;
   }
+
+  .toastCopyContainer {
+    bottom: 90px;
+  }
+
   .icon {
     margin-right: 8px;
     width: 20px;
@@ -65,6 +70,12 @@
     height: 48px;
     padding: 10px 24px;
   }
+
+  .toastCopyContainer {
+    bottom: 90px;
+    height: 54px;
+  }
+
   .icon {
     margin-right: 8px;
     width: 20px;

--- a/src/page/user/costCall/index.tsx
+++ b/src/page/user/costCall/index.tsx
@@ -28,7 +28,7 @@ export default function UserCostCallPage() {
     arrival: false,
   });
 
-  const { data, isLoading, error } = useGetCustomer();
+  const { data, isLoading, isFetching, error } = useGetCustomer();
 
   const handleErrorClick = () => {
     direction_root();
@@ -69,7 +69,7 @@ export default function UserCostCallPage() {
         </>
       ) : (
         <div className={style.noContents}>
-          {isLoading ? (
+          {isLoading || isFetching ? (
             <LoadingSpinner />
           ) : (
             <NoContents


### PR DESCRIPTION
#### 추가사항

- [x] toast 겹치는 문제 해결

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ]

#### 테스트 완료 여부



- [ ] 테스트 완료

#### 스크린샷
<img width="679" alt="스크린샷 2025-01-13 오전 9 21 53" src="https://github.com/user-attachments/assets/6c9dde1d-62f0-4c12-ae79-5ffac1859bcc" />
<img width="833" alt="스크린샷 2025-01-13 오전 9 23 40" src="https://github.com/user-attachments/assets/b020a5a5-d91d-481b-8d85-f238fd359d88" />
![image](이미지url)


#### 코멘트

