### PR TITLE
[김민서] 기사님 상세 페이지 지정 견적 요청 성공 및 실패 시 상태별 모달 알림 기능 추가

### DIFF
--- a/src/page/root/driverDetail/index.tsx
+++ b/src/page/root/driverDetail/index.tsx
@@ -148,7 +148,7 @@ const DriverDetailPage = () => {
         setErrorModalMessage('권한이 없습니다. 로그인 후 다시 시도해주세요.');
         setIsLoginModalOpen(true); // 로그인 모달
       } else if (status === 403) {
-        setErrorModalMessage('소비자 전용 API입니다. 접근 권한이 없습니다.');
+        setErrorModalMessage('이 서비스는 소비자 전용입니다. 접근 권한이 없습니다.');
       } else if (status === 404) {
         setErrorModalMessage(`${driver.moverName} 기사님은 존재하지 않습니다.`);
       } else if (status === 500) {

--- a/src/page/root/driverDetail/index.tsx
+++ b/src/page/root/driverDetail/index.tsx
@@ -86,12 +86,6 @@ const DriverDetailPage = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  useEffect(() => {
-    if (driver) {
-      console.log('기사 상세 데이터:', driver);
-    }
-  }, [driver]);
-
   const handleFavoriteToggle = () => {
     if (!driver) {
       console.error('기사님 데이터가 없습니다.');
@@ -163,7 +157,7 @@ const DriverDetailPage = () => {
         );
       } else {
         setErrorModalMessage(
-          `알 수 없는 오류가 발생했습니다. 다시 시도해주세요. (상태 코드: ${status})`,
+          `알 수 없는 오류가 발생했습니다. 다시 시도해주세요. (오류 코드: ${status})`,
         );
       }
     };
@@ -183,7 +177,6 @@ const DriverDetailPage = () => {
         },
 
         onError: (error: any) => {
-
           const status = error.status || error.response?.status;
           const message = error.message || error.response?.data?.message;
 

--- a/src/page/root/driverDetail/index.tsx
+++ b/src/page/root/driverDetail/index.tsx
@@ -52,6 +52,8 @@ const DriverDetailPage = () => {
 
   const [isMobileView, setIsMobileView] = useState(window.innerWidth <= 1199);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isAssignedEstimateReqOpen, setIsAssignedEstimateReqOpen] =
+    useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [isAssigned, setIsAssigned] = useState(false);
   const [isFavorite, setIsFavorite] = useState(false);
@@ -115,40 +117,82 @@ const DriverDetailPage = () => {
       return;
     }
 
+    // 공통 에러 처리 함수
+    const handleErrorResponse = (status: number, message: string) => {
+      if (status === 400) {
+        switch (message) {
+          case '존재하지 않는 기사님입니다.':
+            setErrorModalMessage(
+              `${driver.moverName} 기사님은 존재하지 않습니다.`,
+            );
+            break;
+          case '일반 견적 요청을 먼저 진행해 주세요.':
+            setErrorModalMessage(
+              `먼저 ${driver.moverName} 기사님에게 일반 견적 요청을 진행해주세요.`,
+            );
+            setIsModalOpen(true); // 일반 견적 요청 모달
+            break;
+          case '해당 기사가 보낸 견적이 존재 합니다.':
+            setErrorModalMessage(
+              `${driver.moverName} 기사님이 이미 견적을 보냈습니다.`,
+            );
+            break;
+          case '이미 기사님께 지정 견적 요청을 하셨습니다.':
+            setErrorModalMessage(
+              `이미 ${driver.moverName} 기사님께 지정 견적 요청을 하셨습니다.`,
+            );
+            break;
+          case '해당 기사님의 서비스 지역이 아닙니다.':
+            setErrorModalMessage(
+              `${driver.moverName} 기사님은 해당 지역에서 서비스를 제공하지 않습니다.`,
+            );
+            break;
+          default:
+            setErrorModalMessage('요청이 잘못되었습니다. 다시 시도해주세요.');
+        }
+      } else if (status === 401) {
+        setErrorModalMessage('권한이 없습니다. 로그인 후 다시 시도해주세요.');
+        setIsLoginModalOpen(true); // 로그인 모달
+      } else if (status === 403) {
+        setErrorModalMessage('소비자 전용 API입니다. 접근 권한이 없습니다.');
+      } else if (status === 404) {
+        setErrorModalMessage(`${driver.moverName} 기사님은 존재하지 않습니다.`);
+      } else if (status === 500) {
+        setErrorModalMessage(
+          '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        );
+      } else {
+        setErrorModalMessage(
+          `알 수 없는 오류가 발생했습니다. 다시 시도해주세요. (상태 코드: ${status})`,
+        );
+      }
+    };
+
     if (!isAssigned && driver.isConfirmed) {
       requestAssignedEstimate(driver.id, {
         onSuccess: (data) => {
-          if (data?.status === 200 && data?.success) {
-            refetch();
-            setIsAssigned(true); // 성공 시에만 true
-          } else {
-            setIsAssigned(false);
-            setErrorModalMessage(
-              `${driver?.moverName} 기사님의 서비스 지역이 아닙니다.`,
-            );
+          const status = data?.status;
+
+          if (status === 201) {
+            if (!isAssigned) {
+              refetch();
+              setIsAssigned(true);
+              setIsAssignedEstimateReqOpen(true); // 지정 견적 요청 모달
+            }
           }
         },
+
         onError: (error: any) => {
-          console.error('지정 견적 요청 실패:', error);
-          console.log('Error object:', error);
 
           const status = error.status || error.response?.status;
+          const message = error.message || error.response?.data?.message;
 
-          setIsAssigned(false); // 에러 발생 시 상태 초기화
-
-          if (status === 400) {
-            setErrorModalMessage(
-              `${driver?.moverName} 기사님의 서비스 지역이 아닙니다.`,
-            );
-          } else {
-            setErrorModalMessage(
-              '지정 견적 요청 중 알 수 없는 오류가 발생했습니다.',
-            );
-          }
+          setIsAssigned(false);
+          handleErrorResponse(status, message);
         },
       });
     } else if (!driver.isConfirmed) {
-      setIsModalOpen(true);
+      setIsModalOpen(true); // 일반 견적 요청 모달
     }
   };
 
@@ -235,9 +279,9 @@ const DriverDetailPage = () => {
         <div className={style.container}>
           <div className={style.leftFilters}>
             <DriverCard
-              list={{...transformedDriver, isConfirmed:false}}
+              list={{ ...transformedDriver, isConfirmed: false }}
               count={mobileWithChipDriverDetail ? 3 : 6}
-              styles = 'none'
+              styles='none'
             />
             <div className={style.section}>
               <div className={style.border}></div>
@@ -413,6 +457,17 @@ const DriverDetailPage = () => {
             buttonClick={() => navigate('/user/login')}
           />
         )}
+        {isAssignedEstimateReqOpen && (
+          <ModalContainer
+            title='지정 견적 요청 성공'
+            isText={true}
+            text={`${driver.moverName} 기사님에게 지정 견적 요청이 성공적으로 전달되었습니다.`}
+            buttonText='확인'
+            closeBtnClick={() => setIsAssignedEstimateReqOpen(false)}
+            buttonClick={() => setIsAssignedEstimateReqOpen(false)}
+          />
+        )}
+
         {showToast && (
           <Toast
             text='링크 복사가 완료됐습니다.'

--- a/src/page/root/searchDriver/index.tsx
+++ b/src/page/root/searchDriver/index.tsx
@@ -113,7 +113,6 @@ const SearchDriver = () => {
     if (moverList) {
       setMovers((prevMovers) => {
         if (page === 1) {
-          console.log(`검색어 "${searchKeyword}"에 대한 결과:`, moverList.list);
           return moverList.list;
         }
         return [...prevMovers, ...moverList.list]; // 페이지가 증가하면 데이터를 누적
@@ -153,10 +152,6 @@ const SearchDriver = () => {
     }
   }, [pendingMoverList, moverList]);
 
-  useEffect(() => {
-    console.log('기사님 카드:', { movers, hasNextPage });
-  }, [page]);
-
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPendingKeyword(e.target.value);
   };
@@ -170,13 +165,9 @@ const SearchDriver = () => {
   };
 
   const handleLoadMore = () => {
-    console.log('현재 페이지:', page);
-    console.log('다음 페이지 존재:', hasNextPage);
-
     if (hasNextPage) {
       setPage((prevPage) => {
         const nextPage = prevPage + 1;
-        console.log('다음 페이지로 이동:', nextPage);
         return nextPage;
       });
     }
@@ -315,7 +306,7 @@ const SearchDriver = () => {
       <div className={style.favoriteDriversContainer}>
         {favoriteMoverList.slice(0, 3).map((user: Mover, index: number) => (
           <DriverCard
-          key={`${user.moverId ?? 'no-moverId'}-${index}`}
+            key={`${user.moverId ?? 'no-moverId'}-${index}`}
             list={{
               ...user,
               profileImg: user.profileImg || undefined,
@@ -334,7 +325,6 @@ const SearchDriver = () => {
   };
 
   const renderDriverCards = () => {
-
     return (
       <div
         className={`${style.cardContainer} ${
@@ -347,7 +337,7 @@ const SearchDriver = () => {
       >
         {movers.map((user: Mover, index: number) => (
           <DriverCard
-          key={`${user.id ?? 'no-id'}-${index}`}
+            key={`${user.id ?? 'no-id'}-${index}`}
             list={{
               ...user,
               moverId: user.userId,

--- a/src/page/user/costDetail/index.tsx
+++ b/src/page/user/costDetail/index.tsx
@@ -54,7 +54,6 @@ const CostDetail = () => {
 
   useEffect(() => {
     if (estimate) {
-      console.log('견적 상세 데이터:', estimate);
       setIsFavorite(estimate.isFavorite);
       setIsConfirmed(estimate.isConfirmed);
     }
@@ -63,20 +62,13 @@ const CostDetail = () => {
   const handleFavoriteToggle = () => {
     if (!estimate) return;
 
-    console.log('기사님 찜하기 상태 변경 요청:', {
-      moverId: estimate.moverId,
-      현재찜하기상태: isFavorite,
-    });
-
     toggleFavoriteMutation.mutate(estimate.moverId, {
       onSuccess: (data) => {
-        console.log('기사님 찜하기 상태 변경 성공:', data);
 
         setIsFavorite(data.isFavorite);
 
         // 상태가 변경되었을 경우에만 refetch 호출
         if (data.isFavorite !== estimate.isFavorite) {
-          console.log('최신 데이터');
           refetch();
         }
       },
@@ -88,11 +80,9 @@ const CostDetail = () => {
 
   const handleConfirmClick = () => {
     if (!isConfirmed) {
-      console.log('견적 확정 요청:', { estimateId: estimate?.estimateId });
 
       updateEstimateConfirmed(Number(estimate.estimateId), {
         onSuccess: () => {
-          console.log('견적 확정 성공');
           setIsConfirmed(true);
         },
         onError: (error) => {


### PR DESCRIPTION
#### 추가사항

- [x] 지정 견적 요청 성공 및 실패 시 상태별 모달 알림 기능 추가
- **지정 견적 요청 성공 시** 기사님 이름을 포함한 **성공 모달** 추가  
  - 예시: `"유재석 기사님께 지정 견적 요청이 성공적으로 전달되었습니다."` 

- **지정 견적 요청 실패 시** 상태 코드 및 메시지에 따라 **오류 모달** 추가  
- **상태별 오류**모달 메시지
- **400**
  - `"존재하지 않는 기사님입니다."` → `"유재석 기사님은 존재하지 않습니다."`  
  - `"일반 견적 요청을 먼저 진행해 주세요."` → `"먼저 유재석 기사님에게 일반 견적 요청을 진행해주세요."`  
  - `"해당 기사가 보낸 견적이 존재 합니다."` → `"유재석 기사님이 이미 견적을 보냈습니다."`  
  - `"이미 기사님께 지정 견적 요청을 하셨습니다."` → `"이미 유재석 기사님께 지정 견적 요청을 하셨습니다."`  
  - `"해당 기사님의 서비스 지역이 아닙니다."` → `"유재석 기사님은 해당 지역에서 서비스를 제공하지 않습니다."`  

- **401**
  - **로그인 모달 오픈**

- **403**
  - `"이 서비스는 소비자 전용입니다. 접근 권한이 없습니다."`

- **404**
  - `"유재석 기사님은 존재하지 않습니다."`

- **500**
  - `"서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."`

- **기타 에러**
  - `"알 수 없는 오류가 발생했습니다. 다시 시도해주세요. (오류 코드: {status})"`

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ]

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷

### **지정 견적 요청** `성공`
![8B198A94-04C1-4B5F-AE9F-69A61AF2A7ED](https://github.com/user-attachments/assets/0e175212-8213-4236-944d-53fc4ac14000)


### **지정 견적 요청** `실패`
![image](https://github.com/user-attachments/assets/8bcda08b-f4b9-402b-9a23-c2003fa1d1e1)



#### 코멘트

